### PR TITLE
Remove alwaysUse24HourFormat property for FormBuilderDateTimePicker

### DIFF
--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -9,8 +9,6 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 enum InputType { date, time, both }
 
-// enum PickerType { material, cupertino }
-
 /// Field for `Date`, `Time` and `DateTime` input
 class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
   /// The date/time picker dialogs to show.
@@ -102,7 +100,6 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
 
   final InputCounterWidgetBuilder? buildCounter;
 
-  // final VoidCallback onEditingComplete,
   final Radius? cursorRadius;
   final Color? cursorColor;
   final Brightness? keyboardAppearance;
@@ -111,7 +108,6 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
 
   final double cursorWidth;
   final TextCapitalization textCapitalization;
-  final bool alwaysUse24HourFormat;
 
   final String? cancelText;
   final String? confirmText;
@@ -161,7 +157,6 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
     this.transitionBuilder,
     this.textCapitalization = TextCapitalization.none,
     this.useRootNavigator = true,
-    this.alwaysUse24HourFormat = false,
     this.initialEntryMode = DatePickerEntryMode.calendar,
     this.timePickerInitialEntryMode = TimePickerEntryMode.dial,
     this.format,

--- a/test/src/fields/form_builder_date_time_picker_test.dart
+++ b/test/src/fields/form_builder_date_time_picker_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../form_builder_tester.dart';
+
+void main() {
+  group('FormBuilderDateTimePicker --', () {
+    testWidgets('basic', (WidgetTester tester) async {
+      const widgetName = 'fdtp1';
+      final widgetKey = UniqueKey();
+      final dateNow = DateTime.now();
+      const confirmText = 'OK';
+      const cancelText = 'CANCEL';
+
+      final testWidget = FormBuilderDateTimePicker(
+        key: widgetKey,
+        name: widgetName,
+        confirmText: confirmText,
+        cancelText: cancelText,
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+      expect(formSave(), isTrue);
+      expect(formValue(widgetName), equals(null));
+      await tester.tap(find.byKey(widgetKey));
+      await tester.pumpAndSettle();
+      expect(find.text(confirmText), findsOneWidget);
+      expect(find.text(cancelText), findsOneWidget);
+
+      final testDay = dateNow.day - 1 <= 0 ? dateNow.day + 1 : dateNow.day - 1;
+      await tester.tap(find.text(testDay.toString()));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(confirmText));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(confirmText));
+      await tester.pumpAndSettle();
+
+      expect(formSave(), isTrue);
+      expect(formValue<DateTime>(widgetName),
+          DateTime(dateNow.year, dateNow.month, testDay, 12));
+    });
+    group('initial value -', () {
+      testWidgets('to FormBuilder', (WidgetTester tester) async {
+        const widgetName = 'fdtp2';
+        final widgetKey = UniqueKey();
+        final dateFuture = DateTime.now().add(const Duration(days: 10));
+        const confirmText = 'OK';
+        const cancelText = 'CANCEL';
+
+        final testWidget = FormBuilderDateTimePicker(
+          key: widgetKey,
+          name: widgetName,
+          confirmText: confirmText,
+          cancelText: cancelText,
+        );
+
+        await tester.pumpWidget(buildTestableFieldWidget(
+          testWidget,
+          initialValue: {widgetName: dateFuture},
+        ));
+
+        expect(formSave(), isTrue);
+        expect(formValue(widgetName), dateFuture);
+        await tester.tap(find.byKey(widgetKey));
+        await tester.pumpAndSettle();
+        expect(find.text(confirmText), findsOneWidget);
+        expect(find.text(cancelText), findsOneWidget);
+
+        final testDay =
+            dateFuture.day - 1 <= 0 ? dateFuture.day + 1 : dateFuture.day - 1;
+        await tester.tap(find.text(testDay.toString()));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(confirmText));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(confirmText));
+        await tester.pumpAndSettle();
+
+        expect(formSave(), isTrue);
+        expect(
+          formValue<DateTime>(widgetName),
+          DateTime(dateFuture.year, dateFuture.month, testDay, dateFuture.hour,
+              dateFuture.minute, 0, 0),
+        );
+      });
+      testWidgets('to Widget', (WidgetTester tester) async {
+        const widgetName = 'fdtp3';
+        final widgetKey = UniqueKey();
+        final datePast = DateTime.now().subtract(const Duration(days: 10));
+        const confirmText = 'OK';
+        const cancelText = 'CANCEL';
+
+        final testWidget = FormBuilderDateTimePicker(
+          key: widgetKey,
+          name: widgetName,
+          confirmText: confirmText,
+          cancelText: cancelText,
+          initialValue: datePast,
+        );
+
+        await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+        expect(formSave(), isTrue);
+        expect(formValue(widgetName), datePast);
+        await tester.tap(find.byKey(widgetKey));
+        await tester.pumpAndSettle();
+        expect(find.text(confirmText), findsOneWidget);
+        expect(find.text(cancelText), findsOneWidget);
+
+        final testDay =
+            datePast.day - 1 <= 0 ? datePast.day + 1 : datePast.day - 1;
+        await tester.tap(find.text(testDay.toString()));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(confirmText));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(confirmText));
+        await tester.pumpAndSettle();
+
+        expect(formSave(), isTrue);
+        expect(
+          formValue<DateTime>(widgetName),
+          DateTime(datePast.year, datePast.month, testDay, datePast.hour,
+              datePast.minute, 0, 0),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #826 
Close #861 

## Solution description

- Remove property
- Add some tests

## To Do

- [ ] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [ ] Check the original issue to confirm it is fully satisfied
- [ ] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme
