### PR TITLE
Deprecate reset icon from FormBuilderDateTimePicker

### DIFF
--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -40,9 +40,8 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
   /// to noon. Explicitly set this to `null` to use the current time.
   final TimeOfDay initialTime;
 
-  /// If defined, the TextField [decoration]'s [suffixIcon] will be
-  /// overridden to reset the input using the icon defined here.
-  /// Set this to `null` to stop that behavior. Defaults to [Icons.close].
+  @Deprecated(
+      'This property is no used anymore. Please use decoration.suffixIcon to set your desired icon')
   final Widget? resetIcon;
 
   /// Called when an enclosing form is saved. The value passed will be `null`
@@ -213,7 +212,7 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
               textAlign: textAlign,
               maxLength: maxLength,
               autofocus: autofocus,
-              decoration: state.decoration.copyWith(suffixIcon: resetIcon),
+              decoration: state.decoration,
               readOnly: true,
               enabled: state.enabled,
               autocorrect: autocorrect,


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #248
Close #1077 

## Solution description

Remove reset icon and only use decoration to set a suffixIcon

## Screenshots or Videos

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
