### PR TITLE
Clear customError on reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,29 +172,30 @@ FormBuilder(
   child: Column(
     children: [
       FormBuilderTextField(
-        key: _emailFieldKey
+        key: _emailFieldKey,
         name: 'email',
-        decoration: InputDecoration(labelText: 'Email'),
+        decoration: const InputDecoration(labelText: 'Email'),
         validator: FormBuilderValidators.compose([
           FormBuilderValidators.required(),
           FormBuilderValidators.email(),
         ]),
       ),
-      RaisedButton(
-        child: Text('Submit'),
+      ElevatedButton(
+        child: const Text('Submit'),
         onPressed: () async {
           if(await checkIfEmailExists()){
             // Either invalidate using Form Key
-            _formKey.currentState?.invalidateField(name: 'email', errorText: 'Email already taken.');
+            _formKey.currentState?.invalidateField(
+                name: 'email', errorText: 'Email already taken.');
             // OR invalidate using Field Key
-            _emailFieldKey.currentState?.invalidate('Email already taken');
+            _emailFieldKey.currentState
+                ?.invalidate('Email already taken');
           }
         },
       ),
     ],
   ),
 ),
-
 ```
 
 ##### Option 2 - Using InputDecoration.errorText

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -212,6 +212,9 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   void reset() {
     super.reset();
     setValue(initialValue);
+    if (_customErrorText != null) {
+      setState(() => _customErrorText = null);
+    }
     widget.onReset?.call();
   }
 

--- a/test/form_builder_tester.dart
+++ b/test/form_builder_tester.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
-final _formKey = GlobalKey<FormBuilderState>();
+final formKey = GlobalKey<FormBuilderState>();
 
 Widget buildTestableFieldWidget(
   Widget widget, {
@@ -11,7 +11,7 @@ Widget buildTestableFieldWidget(
   return MaterialApp(
     home: Scaffold(
       body: FormBuilder(
-        key: _formKey,
+        key: formKey,
         initialValue: initialValue,
         clearValueOnUnregister: clearValueOnUnregister,
         child: widget,
@@ -20,10 +20,10 @@ Widget buildTestableFieldWidget(
   );
 }
 
-bool formSave() => _formKey.currentState!.saveAndValidate();
+bool formSave() => formKey.currentState!.saveAndValidate();
 void formFieldDidChange(String fieldName, dynamic value) {
-  _formKey.currentState!.fields[fieldName]!.didChange(value);
+  formKey.currentState!.fields[fieldName]!.didChange(value);
 }
 
-T formValue<T>(String name) => _formKey.currentState!.value[name];
-T formInstantValue<T>(String name) => _formKey.currentState!.instantValue[name];
+T formValue<T>(String name) => formKey.currentState!.value[name];
+T formInstantValue<T>(String name) => formKey.currentState!.instantValue[name];

--- a/test/src/form_builder_field_test.dart
+++ b/test/src/form_builder_field_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../form_builder_tester.dart';
+
+void main() {
+  group('Form Builder Field -', () {
+    testWidgets('Reset custom error from form builder', (tester) async {
+      const textFieldName = 'text1';
+      const errorTextField = 'error text field';
+      final testWidget = FormBuilderTextField(name: textFieldName);
+      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+      // Set custom error
+      formKey.currentState
+          ?.invalidateField(name: textFieldName, errorText: errorTextField);
+      await tester.pumpAndSettle();
+      expect(find.text(errorTextField), findsOneWidget);
+
+      // Reset custom error
+      formKey.currentState?.reset();
+      await tester.pumpAndSettle();
+      expect(find.text(errorTextField), findsNothing);
+    });
+    testWidgets('Reset custom error from form builder field', (tester) async {
+      final textFieldKey = GlobalKey<FormBuilderFieldState>();
+      const textFieldName = 'text2';
+      const errorTextField = 'error text field';
+      final testWidget = FormBuilderTextField(
+        name: textFieldName,
+        key: textFieldKey,
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+      // Set custom error
+      textFieldKey.currentState?.invalidate(errorTextField);
+      await tester.pumpAndSettle();
+      expect(find.text(errorTextField), findsOneWidget);
+
+      // Reset custom error
+      textFieldKey.currentState?.reset();
+      await tester.pumpAndSettle();
+      expect(find.text(errorTextField), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #977 

## Solution description

Clear customErrorText when call reset on field

## Screenshots or Videos

https://user-images.githubusercontent.com/21011641/181925688-6367f0b3-92fb-4095-a704-2dd19d147374.mp4

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
