### PR TITLE
feat(fields): add cursorHeight property for form builder text field

### DIFF
--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -160,6 +160,9 @@ class FormBuilderTextField extends FormBuilderField<String> {
   /// {@macro flutter.widgets.editableText.cursorWidth}
   final double cursorWidth;
 
+  /// {@macro flutter.widgets.editableText.cursorHeight}
+  final double? cursorHeight;
+
   /// {@macro flutter.widgets.editableText.cursorRadius}
   final Radius? cursorRadius;
 
@@ -307,6 +310,7 @@ class FormBuilderTextField extends FormBuilderField<String> {
     this.autofocus = false,
     this.autocorrect = true,
     this.cursorWidth = 2.0,
+    this.cursorHeight,
     this.keyboardType,
     this.style,
     this.controller,
@@ -399,6 +403,7 @@ class FormBuilderTextField extends FormBuilderField<String> {
               inputFormatters: inputFormatters,
               enabled: state.enabled,
               cursorWidth: cursorWidth,
+              cursorHeight: cursorHeight,
               cursorRadius: cursorRadius,
               cursorColor: cursorColor,
               scrollPadding: scrollPadding,


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #719

## Solution description
Simply added the delegation to `TextField` like `cursorWidth`. However I was not able to test this with the _example_ project. There is some contribution documentation missing on how to build the package locally to use it in the example project.

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [ ] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme
