### PR TITLE
Use dart 2.17 super initiliazers to simplify code

### DIFF
--- a/lib/src/fields/form_builder_checkbox.dart
+++ b/lib/src/fields/form_builder_checkbox.dart
@@ -68,25 +68,24 @@ class FormBuilderCheckbox extends FormBuilderField<bool> {
 
   /// Creates a single Checkbox field
   FormBuilderCheckbox({
-    //From Super
-    Key? key,
-    required String name,
-    FormFieldValidator<bool>? validator,
-    bool? initialValue,
-    InputDecoration decoration = const InputDecoration(
+    super.key,
+    required super.name,
+    super.validator,
+    super.initialValue,
+    super.decoration = const InputDecoration(
       border: InputBorder.none,
       focusedBorder: InputBorder.none,
       enabledBorder: InputBorder.none,
       errorBorder: InputBorder.none,
       disabledBorder: InputBorder.none,
     ),
-    ValueChanged<bool?>? onChanged,
-    ValueTransformer<bool?>? valueTransformer,
-    bool enabled = true,
-    FormFieldSetter<bool?>? onSaved,
-    AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
-    VoidCallback? onReset,
-    FocusNode? focusNode,
+    super.onChanged,
+    super.valueTransformer,
+    super.enabled,
+    super.onSaved,
+    super.autovalidateMode = AutovalidateMode.disabled,
+    super.onReset,
+    super.focusNode,
     required this.title,
     this.activeColor,
     this.autofocus = false,
@@ -99,18 +98,6 @@ class FormBuilderCheckbox extends FormBuilderField<bool> {
     this.subtitle,
     this.tristate = false,
   }) : super(
-          key: key,
-          initialValue: initialValue,
-          name: name,
-          validator: validator,
-          valueTransformer: valueTransformer,
-          onChanged: onChanged,
-          autovalidateMode: autovalidateMode,
-          onSaved: onSaved,
-          enabled: enabled,
-          onReset: onReset,
-          decoration: decoration,
-          focusNode: focusNode,
           builder: (FormFieldState<bool?> field) {
             final state = field as _FormBuilderCheckboxState;
 

--- a/lib/src/fields/form_builder_checkbox_group.dart
+++ b/lib/src/fields/form_builder_checkbox_group.dart
@@ -27,19 +27,18 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderField<List<T>> {
 
   /// Creates a list of Checkboxes for selecting multiple options
   FormBuilderCheckboxGroup({
-    Key? key,
-    //From Super
-    required String name,
-    FormFieldValidator<List<T>>? validator,
-    List<T>? initialValue,
-    InputDecoration decoration = const InputDecoration(),
-    ValueChanged<List<T>?>? onChanged,
-    ValueTransformer<List<T>?>? valueTransformer,
-    bool enabled = true,
-    FormFieldSetter<List<T>>? onSaved,
-    AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
-    VoidCallback? onReset,
-    FocusNode? focusNode,
+    super.key,
+    required super.name,
+    super.validator,
+    super.initialValue,
+    super.decoration,
+    super.onChanged,
+    super.valueTransformer,
+    super.enabled,
+    super.onSaved,
+    super.autovalidateMode = AutovalidateMode.disabled,
+    super.onReset,
+    super.focusNode,
     required this.options,
     this.activeColor,
     this.checkColor,
@@ -61,18 +60,6 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderField<List<T>> {
     this.orientation = OptionsOrientation.wrap,
     this.shouldRequestFocus = false,
   }) : super(
-          key: key,
-          initialValue: initialValue,
-          name: name,
-          validator: validator,
-          valueTransformer: valueTransformer,
-          onChanged: onChanged,
-          autovalidateMode: autovalidateMode,
-          onSaved: onSaved,
-          enabled: enabled,
-          onReset: onReset,
-          decoration: decoration,
-          focusNode: focusNode,
           builder: (FormFieldState<List<T>?> field) {
             final state = field as _FormBuilderCheckboxGroupState<T>;
 

--- a/lib/src/fields/form_builder_choice_chips.dart
+++ b/lib/src/fields/form_builder_choice_chips.dart
@@ -256,16 +256,16 @@ class FormBuilderChoiceChip<T> extends FormBuilderField<T> {
 
   /// Creates a list of `Chip`s that acts like radio buttons
   FormBuilderChoiceChip({
-    AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
-    bool enabled = true,
-    FocusNode? focusNode,
-    FormFieldSetter<T>? onSaved,
-    FormFieldValidator<T>? validator,
-    InputDecoration decoration = const InputDecoration(),
-    Key? key,
-    required String name, //From Super
+    super.autovalidateMode = AutovalidateMode.disabled,
+    super.enabled,
+    super.focusNode,
+    super.onSaved,
+    super.validator,
+    super.decoration,
+    super.key,
+    required super.name,
     required this.options,
-    T? initialValue,
+    super.initialValue,
     this.alignment = WrapAlignment.start,
     this.avatarBorder = const CircleBorder(),
     this.backgroundColor,
@@ -289,22 +289,10 @@ class FormBuilderChoiceChip<T> extends FormBuilderField<T> {
     this.textDirection,
     this.verticalDirection = VerticalDirection.down,
     this.visualDensity,
-    ValueChanged<T?>? onChanged,
-    ValueTransformer<T?>? valueTransformer,
-    VoidCallback? onReset,
+    super.onChanged,
+    super.valueTransformer,
+    super.onReset,
   }) : super(
-            key: key,
-            initialValue: initialValue,
-            name: name,
-            validator: validator,
-            valueTransformer: valueTransformer,
-            onChanged: onChanged,
-            autovalidateMode: autovalidateMode,
-            onSaved: onSaved,
-            enabled: enabled,
-            onReset: onReset,
-            decoration: decoration,
-            focusNode: focusNode,
             builder: (FormFieldState<T?> field) {
               final state = field as _FormBuilderChoiceChipState<T>;
 

--- a/lib/src/fields/form_builder_choice_chips.dart
+++ b/lib/src/fields/form_builder_choice_chips.dart
@@ -292,55 +292,54 @@ class FormBuilderChoiceChip<T> extends FormBuilderField<T> {
     super.onChanged,
     super.valueTransformer,
     super.onReset,
-  }) : super(
-            builder: (FormFieldState<T?> field) {
-              final state = field as _FormBuilderChoiceChipState<T>;
+  }) : super(builder: (FormFieldState<T?> field) {
+          final state = field as _FormBuilderChoiceChipState<T>;
 
-              return InputDecorator(
-                decoration: state.decoration,
-                child: Wrap(
-                  direction: direction,
-                  alignment: alignment,
-                  crossAxisAlignment: crossAxisAlignment,
-                  runAlignment: runAlignment,
-                  runSpacing: runSpacing,
-                  spacing: spacing,
-                  textDirection: textDirection,
-                  verticalDirection: verticalDirection,
-                  children: <Widget>[
-                    for (FormBuilderChipOption<T> option in options)
-                      ChoiceChip(
-                        label: option,
-                        shape: shape,
-                        selected: field.value == option.value,
-                        onSelected: state.enabled
-                            ? (selected) {
-                                final choice = selected ? option.value : null;
-                                if (shouldRequestFocus) {
-                                  state.requestFocus();
-                                }
-                                state.didChange(choice);
-                              }
-                            : null,
-                        avatar: option.avatar,
-                        selectedColor: selectedColor,
-                        disabledColor: disabledColor,
-                        backgroundColor: backgroundColor,
-                        shadowColor: shadowColor,
-                        selectedShadowColor: selectedShadowColor,
-                        elevation: elevation,
-                        pressElevation: pressElevation,
-                        materialTapTargetSize: materialTapTargetSize,
-                        labelStyle: labelStyle,
-                        labelPadding: labelPadding,
-                        padding: padding,
-                        visualDensity: visualDensity,
-                        avatarBorder: avatarBorder,
-                      ),
-                  ],
-                ),
-              );
-            });
+          return InputDecorator(
+            decoration: state.decoration,
+            child: Wrap(
+              direction: direction,
+              alignment: alignment,
+              crossAxisAlignment: crossAxisAlignment,
+              runAlignment: runAlignment,
+              runSpacing: runSpacing,
+              spacing: spacing,
+              textDirection: textDirection,
+              verticalDirection: verticalDirection,
+              children: <Widget>[
+                for (FormBuilderChipOption<T> option in options)
+                  ChoiceChip(
+                    label: option,
+                    shape: shape,
+                    selected: field.value == option.value,
+                    onSelected: state.enabled
+                        ? (selected) {
+                            final choice = selected ? option.value : null;
+                            if (shouldRequestFocus) {
+                              state.requestFocus();
+                            }
+                            state.didChange(choice);
+                          }
+                        : null,
+                    avatar: option.avatar,
+                    selectedColor: selectedColor,
+                    disabledColor: disabledColor,
+                    backgroundColor: backgroundColor,
+                    shadowColor: shadowColor,
+                    selectedShadowColor: selectedShadowColor,
+                    elevation: elevation,
+                    pressElevation: pressElevation,
+                    materialTapTargetSize: materialTapTargetSize,
+                    labelStyle: labelStyle,
+                    labelPadding: labelPadding,
+                    padding: padding,
+                    visualDensity: visualDensity,
+                    avatarBorder: avatarBorder,
+                  ),
+              ],
+            ),
+          );
+        });
 
   @override
   FormBuilderFieldState<FormBuilderChoiceChip<T>, T> createState() =>

--- a/lib/src/fields/form_builder_date_range_picker.dart
+++ b/lib/src/fields/form_builder_date_range_picker.dart
@@ -64,19 +64,18 @@ class FormBuilderDateRangePicker extends FormBuilderField<DateTimeRange> {
 
   /// Creates field for selecting a range of dates
   FormBuilderDateRangePicker({
-    Key? key,
-    //From Super
-    required String name,
-    FormFieldValidator<DateTimeRange>? validator,
-    DateTimeRange? initialValue,
-    InputDecoration decoration = const InputDecoration(),
-    ValueChanged<DateTimeRange?>? onChanged,
-    ValueTransformer<DateTimeRange?>? valueTransformer,
-    bool enabled = true,
-    FormFieldSetter<DateTimeRange>? onSaved,
-    AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
-    VoidCallback? onReset,
-    FocusNode? focusNode,
+    super.key,
+    required super.name,
+    super.validator,
+    super.initialValue,
+    super.decoration,
+    super.onChanged,
+    super.valueTransformer,
+    super.enabled,
+    super.onSaved,
+    super.autovalidateMode = AutovalidateMode.disabled,
+    super.onReset,
+    super.focusNode,
     required this.firstDate,
     required this.lastDate,
     this.format,
@@ -129,18 +128,6 @@ class FormBuilderDateRangePicker extends FormBuilderField<DateTimeRange> {
     this.allowClear = false,
     this.clearIcon,
   }) : super(
-          key: key,
-          initialValue: initialValue,
-          name: name,
-          validator: validator,
-          valueTransformer: valueTransformer,
-          onChanged: onChanged,
-          autovalidateMode: autovalidateMode,
-          onSaved: onSaved,
-          enabled: enabled,
-          onReset: onReset,
-          decoration: decoration,
-          focusNode: focusNode,
           builder: (FormFieldState<DateTimeRange?> field) {
             final state = field as _FormBuilderDateRangePickerState;
 

--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -127,19 +127,18 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
 
   /// Creates field for `Date`, `Time` and `DateTime` input
   FormBuilderDateTimePicker({
-    Key? key,
-    //From Super
-    required String name,
-    FormFieldValidator<DateTime>? validator,
-    DateTime? initialValue,
-    InputDecoration decoration = const InputDecoration(),
-    ValueChanged<DateTime?>? onChanged,
-    ValueTransformer<DateTime?>? valueTransformer,
-    bool enabled = true,
-    FormFieldSetter<DateTime>? onSaved,
-    AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
-    VoidCallback? onReset,
-    FocusNode? focusNode,
+    super.key,
+    required super.name,
+    super.validator,
+    super.initialValue,
+    super.decoration,
+    super.onChanged,
+    super.valueTransformer,
+    super.enabled,
+    super.onSaved,
+    super.autovalidateMode = AutovalidateMode.disabled,
+    super.onReset,
+    super.focusNode,
     this.inputType = InputType.both,
     this.scrollPadding = const EdgeInsets.all(20.0),
     this.cursorWidth = 2.0,
@@ -194,18 +193,6 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
     this.anchorPoint,
     this.onEntryModeChanged,
   }) : super(
-          key: key,
-          initialValue: initialValue,
-          name: name,
-          validator: validator,
-          valueTransformer: valueTransformer,
-          onChanged: onChanged,
-          autovalidateMode: autovalidateMode,
-          onSaved: onSaved,
-          enabled: enabled,
-          onReset: onReset,
-          decoration: decoration,
-          focusNode: focusNode,
           builder: (FormFieldState<DateTime?> field) {
             final state = field as _FormBuilderDateTimePickerState;
 

--- a/lib/src/fields/form_builder_filter_chips.dart
+++ b/lib/src/fields/form_builder_filter_chips.dart
@@ -36,15 +36,15 @@ class FormBuilderFilterChip<T> extends FormBuilderField<List<T>> {
 
   /// Creates field with chips that acts like a list checkboxes.
   FormBuilderFilterChip({
-    AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
-    bool enabled = true,
-    FocusNode? focusNode,
-    FormFieldSetter<List<T>>? onSaved,
-    FormFieldValidator<List<T>>? validator,
-    InputDecoration decoration = const InputDecoration(),
-    Key? key,
-    List<T>? initialValue,
-    required String name, // From Super
+    super.autovalidateMode = AutovalidateMode.disabled,
+    super.enabled,
+    super.focusNode,
+    super.onSaved,
+    super.validator,
+    super.decoration,
+    super.key,
+    super.initialValue,
+    required super.name,
     required this.options,
     this.alignment = WrapAlignment.start,
     this.avatarBorder = const CircleBorder(),
@@ -72,23 +72,11 @@ class FormBuilderFilterChip<T> extends FormBuilderField<List<T>> {
     this.spacing = 0.0,
     this.textDirection,
     this.verticalDirection = VerticalDirection.down,
-    ValueChanged<List<T>?>? onChanged,
-    ValueTransformer<List<T>?>? valueTransformer,
-    VoidCallback? onReset,
+    super.onChanged,
+    super.valueTransformer,
+    super.onReset,
   })  : assert((maxChips == null) || ((initialValue ?? []).length <= maxChips)),
         super(
-          autovalidateMode: autovalidateMode,
-          decoration: decoration,
-          enabled: enabled,
-          focusNode: focusNode,
-          initialValue: initialValue,
-          key: key,
-          name: name,
-          onChanged: onChanged,
-          onReset: onReset,
-          onSaved: onSaved,
-          validator: validator,
-          valueTransformer: valueTransformer,
           builder: (FormFieldState<List<T>?> field) {
             final state = field as _FormBuilderFilterChipState<T>;
             final fieldValue = field.value ?? [];

--- a/lib/src/fields/form_builder_radio_group.dart
+++ b/lib/src/fields/form_builder_radio_group.dart
@@ -25,16 +25,16 @@ class FormBuilderRadioGroup<T> extends FormBuilderField<T> {
 
   /// Creates field to select one value from a list of Radio Widgets
   FormBuilderRadioGroup({
-    AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
-    bool enabled = true,
-    FocusNode? focusNode,
-    FormFieldSetter<T>? onSaved,
-    FormFieldValidator<T>? validator,
-    InputDecoration decoration = const InputDecoration(),
-    Key? key,
-    required String name, //From Super
+    super.autovalidateMode = AutovalidateMode.disabled,
+    super.enabled,
+    super.focusNode,
+    super.onSaved,
+    super.validator,
+    super.decoration,
+    super.key,
+    required super.name,
     required this.options,
-    T? initialValue,
+    super.initialValue,
     this.shouldRadioRequestFocus = false,
     this.activeColor,
     this.controlAffinity = ControlAffinity.leading,
@@ -52,22 +52,10 @@ class FormBuilderRadioGroup<T> extends FormBuilderField<T> {
     this.wrapSpacing = 0.0,
     this.wrapTextDirection,
     this.wrapVerticalDirection = VerticalDirection.down,
-    ValueChanged<T?>? onChanged,
-    ValueTransformer<T?>? valueTransformer,
-    VoidCallback? onReset,
+    super.onChanged,
+    super.valueTransformer,
+    super.onReset,
   }) : super(
-          key: key,
-          initialValue: initialValue,
-          name: name,
-          validator: validator,
-          valueTransformer: valueTransformer,
-          onChanged: onChanged,
-          autovalidateMode: autovalidateMode,
-          onSaved: onSaved,
-          enabled: enabled,
-          onReset: onReset,
-          focusNode: focusNode,
-          decoration: decoration,
           builder: (FormFieldState<T?> field) {
             final state = field as _FormBuilderRadioGroupState<T>;
 

--- a/lib/src/fields/form_builder_range_slider.dart
+++ b/lib/src/fields/form_builder_range_slider.dart
@@ -133,68 +133,66 @@ class FormBuilderRangeSlider extends FormBuilderField<RangeValues> {
     this.maxTextStyle,
     this.numberFormat,
     this.shouldRequestFocus = false,
-  }) : super(
-            builder: (FormFieldState<RangeValues?> field) {
-              final state = field as _FormBuilderRangeSliderState;
-              final effectiveNumberFormat =
-                  numberFormat ?? NumberFormat.compact();
+  }) : super(builder: (FormFieldState<RangeValues?> field) {
+          final state = field as _FormBuilderRangeSliderState;
+          final effectiveNumberFormat = numberFormat ?? NumberFormat.compact();
 
-              return InputDecorator(
-                decoration: state.decoration,
-                child: Container(
-                  padding: const EdgeInsets.only(top: 10.0),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      RangeSlider(
-                        values: field.value ?? RangeValues(min, min),
-                        min: min,
-                        max: max,
-                        divisions: divisions,
-                        activeColor: activeColor,
-                        inactiveColor: inactiveColor,
-                        onChangeEnd: onChangeEnd,
-                        onChangeStart: onChangeStart,
-                        labels: labels,
-                        semanticFormatterCallback: semanticFormatterCallback,
-                        onChanged: state.enabled
-                            ? (values) {
-                                if (shouldRequestFocus) {
-                                  state.requestFocus();
-                                }
-                                field.didChange(values);
-                              }
-                            : null,
-                      ),
-                      Row(
-                        children: <Widget>[
-                          if (displayValues != DisplayValues.none &&
-                              displayValues != DisplayValues.current)
-                            Text(
-                              effectiveNumberFormat.format(min),
-                              style: minTextStyle ?? textStyle,
-                            ),
-                          const Spacer(),
-                          if (displayValues != DisplayValues.none &&
-                              displayValues != DisplayValues.minMax)
-                            Text(
-                              '${effectiveNumberFormat.format(field.value!.start)} - ${effectiveNumberFormat.format(field.value!.end)}',
-                              style: textStyle,
-                            ),
-                          const Spacer(),
-                          if (displayValues != DisplayValues.none &&
-                              displayValues != DisplayValues.current)
-                            Text(
-                              effectiveNumberFormat.format(max),
-                              style: maxTextStyle ?? textStyle,
-                            ),
-                        ],
-                      ),
+          return InputDecorator(
+            decoration: state.decoration,
+            child: Container(
+              padding: const EdgeInsets.only(top: 10.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  RangeSlider(
+                    values: field.value ?? RangeValues(min, min),
+                    min: min,
+                    max: max,
+                    divisions: divisions,
+                    activeColor: activeColor,
+                    inactiveColor: inactiveColor,
+                    onChangeEnd: onChangeEnd,
+                    onChangeStart: onChangeStart,
+                    labels: labels,
+                    semanticFormatterCallback: semanticFormatterCallback,
+                    onChanged: state.enabled
+                        ? (values) {
+                            if (shouldRequestFocus) {
+                              state.requestFocus();
+                            }
+                            field.didChange(values);
+                          }
+                        : null,
+                  ),
+                  Row(
+                    children: <Widget>[
+                      if (displayValues != DisplayValues.none &&
+                          displayValues != DisplayValues.current)
+                        Text(
+                          effectiveNumberFormat.format(min),
+                          style: minTextStyle ?? textStyle,
+                        ),
+                      const Spacer(),
+                      if (displayValues != DisplayValues.none &&
+                          displayValues != DisplayValues.minMax)
+                        Text(
+                          '${effectiveNumberFormat.format(field.value!.start)} - ${effectiveNumberFormat.format(field.value!.end)}',
+                          style: textStyle,
+                        ),
+                      const Spacer(),
+                      if (displayValues != DisplayValues.none &&
+                          displayValues != DisplayValues.current)
+                        Text(
+                          effectiveNumberFormat.format(max),
+                          style: maxTextStyle ?? textStyle,
+                        ),
                     ],
                   ),
-                ),
-              );
-            });
+                ],
+              ),
+            ),
+          );
+        });
 
   @override
   FormBuilderFieldState<FormBuilderRangeSlider, RangeValues> createState() =>

--- a/lib/src/fields/form_builder_range_slider.dart
+++ b/lib/src/fields/form_builder_range_slider.dart
@@ -106,19 +106,18 @@ class FormBuilderRangeSlider extends FormBuilderField<RangeValues> {
 
   /// Creates field to select a range of values on a Slider
   FormBuilderRangeSlider({
-    Key? key,
-    //From Super
-    required String name,
-    FormFieldValidator<RangeValues>? validator,
-    RangeValues? initialValue,
-    InputDecoration decoration = const InputDecoration(),
-    ValueChanged<RangeValues?>? onChanged,
-    ValueTransformer<RangeValues?>? valueTransformer,
-    bool enabled = true,
-    FormFieldSetter<RangeValues>? onSaved,
-    AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
-    VoidCallback? onReset,
-    FocusNode? focusNode,
+    super.key,
+    required super.name,
+    super.validator,
+    super.initialValue,
+    super.decoration,
+    super.onChanged,
+    super.valueTransformer,
+    super.enabled,
+    super.onSaved,
+    super.autovalidateMode = AutovalidateMode.disabled,
+    super.onReset,
+    super.focusNode,
     required this.min,
     required this.max,
     this.divisions,
@@ -135,18 +134,6 @@ class FormBuilderRangeSlider extends FormBuilderField<RangeValues> {
     this.numberFormat,
     this.shouldRequestFocus = false,
   }) : super(
-            key: key,
-            initialValue: initialValue,
-            name: name,
-            validator: validator,
-            valueTransformer: valueTransformer,
-            onChanged: onChanged,
-            autovalidateMode: autovalidateMode,
-            onSaved: onSaved,
-            enabled: enabled,
-            onReset: onReset,
-            decoration: decoration,
-            focusNode: focusNode,
             builder: (FormFieldState<RangeValues?> field) {
               final state = field as _FormBuilderRangeSliderState;
               final effectiveNumberFormat =

--- a/lib/src/fields/form_builder_segmented_control.dart
+++ b/lib/src/fields/form_builder_segmented_control.dart
@@ -41,19 +41,18 @@ class FormBuilderSegmentedControl<T extends Object>
 
   /// Creates field for selection of a value from the `CupertinoSegmentedControl`
   FormBuilderSegmentedControl({
-    Key? key,
-    //From Super
-    required String name,
-    FormFieldValidator<T>? validator,
-    T? initialValue,
-    InputDecoration decoration = const InputDecoration(),
-    ValueChanged<T?>? onChanged,
-    ValueTransformer<T?>? valueTransformer,
-    bool enabled = true,
-    FormFieldSetter<T>? onSaved,
-    AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
-    VoidCallback? onReset,
-    FocusNode? focusNode,
+    super.key,
+    required super.name,
+    super.validator,
+    super.initialValue,
+    super.decoration,
+    super.onChanged,
+    super.valueTransformer,
+    super.enabled,
+    super.onSaved,
+    super.autovalidateMode = AutovalidateMode.disabled,
+    super.onReset,
+    super.focusNode,
     required this.options,
     this.borderColor,
     this.selectedColor,
@@ -62,18 +61,6 @@ class FormBuilderSegmentedControl<T extends Object>
     this.unselectedColor,
     this.shouldRequestFocus = false,
   }) : super(
-          key: key,
-          initialValue: initialValue,
-          name: name,
-          validator: validator,
-          valueTransformer: valueTransformer,
-          onChanged: onChanged,
-          autovalidateMode: autovalidateMode,
-          onSaved: onSaved,
-          enabled: enabled,
-          onReset: onReset,
-          decoration: decoration,
-          focusNode: focusNode,
           builder: (FormFieldState<T?> field) {
             final state = field as _FormBuilderSegmentedControlState<T>;
             final theme = Theme.of(state.context);

--- a/lib/src/fields/form_builder_slider.dart
+++ b/lib/src/fields/form_builder_slider.dart
@@ -131,19 +131,18 @@ class FormBuilderSlider extends FormBuilderField<double> {
 
   /// Creates field for selection of a numerical value on a slider
   FormBuilderSlider({
-    Key? key,
-    //From Super
-    required String name,
-    FormFieldValidator<double>? validator,
-    required double initialValue,
-    InputDecoration decoration = const InputDecoration(),
-    ValueChanged<double?>? onChanged,
-    ValueTransformer<double?>? valueTransformer,
-    bool enabled = true,
-    FormFieldSetter<double>? onSaved,
-    AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
-    VoidCallback? onReset,
-    FocusNode? focusNode,
+    super.key,
+    required super.name,
+    super.validator,
+    required double super.initialValue,
+    super.decoration,
+    super.onChanged,
+    super.valueTransformer,
+    super.enabled,
+    super.onSaved,
+    super.autovalidateMode = AutovalidateMode.disabled,
+    super.onReset,
+    super.focusNode,
     required this.min,
     required this.max,
     this.divisions,
@@ -162,18 +161,6 @@ class FormBuilderSlider extends FormBuilderField<double> {
     this.mouseCursor,
     this.shouldRequestFocus = false,
   }) : super(
-          key: key,
-          initialValue: initialValue,
-          name: name,
-          validator: validator,
-          valueTransformer: valueTransformer,
-          onChanged: onChanged,
-          autovalidateMode: autovalidateMode,
-          onSaved: onSaved,
-          enabled: enabled,
-          onReset: onReset,
-          decoration: decoration,
-          focusNode: focusNode,
           builder: (FormFieldState<double?> field) {
             final state = field as _FormBuilderSliderState;
             final effectiveNumberFormat =

--- a/lib/src/fields/form_builder_switch.dart
+++ b/lib/src/fields/form_builder_switch.dart
@@ -83,19 +83,18 @@ class FormBuilderSwitch extends FormBuilderField<bool> {
 
   /// Creates On/Off switch field
   FormBuilderSwitch({
-    Key? key,
-    //From Super
-    required String name,
-    FormFieldValidator<bool>? validator,
-    bool? initialValue,
-    InputDecoration decoration = const InputDecoration(),
-    ValueChanged<bool?>? onChanged,
-    ValueTransformer<bool?>? valueTransformer,
-    bool enabled = true,
-    FormFieldSetter<bool>? onSaved,
-    AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
-    VoidCallback? onReset,
-    FocusNode? focusNode,
+    super.key,
+    required super.name,
+    super.validator,
+    super.initialValue,
+    super.decoration,
+    super.onChanged,
+    super.valueTransformer,
+    super.enabled,
+    super.onSaved,
+    super.autovalidateMode = AutovalidateMode.disabled,
+    super.onReset,
+    super.focusNode,
     required this.title,
     this.activeColor,
     this.activeTrackColor,
@@ -111,18 +110,6 @@ class FormBuilderSwitch extends FormBuilderField<bool> {
     this.shouldRequestFocus = false,
     this.selected = false,
   }) : super(
-          key: key,
-          initialValue: initialValue,
-          name: name,
-          validator: validator,
-          valueTransformer: valueTransformer,
-          onChanged: onChanged,
-          autovalidateMode: autovalidateMode,
-          onSaved: onSaved,
-          enabled: enabled,
-          onReset: onReset,
-          decoration: decoration,
-          focusNode: focusNode,
           builder: (FormFieldState<bool?> field) {
             final state = field as _FormBuilderSwitchState;
 

--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -286,20 +286,19 @@ class FormBuilderTextField extends FormBuilderField<String> {
 
   /// Creates a Material Design text field input.
   FormBuilderTextField({
-    Key? key,
-    //From Super
-    required String name,
-    FormFieldValidator<String>? validator,
+    super.key,
+    required super.name,
+    super.validator,
     String? initialValue,
     bool readOnly = false,
-    InputDecoration decoration = const InputDecoration(),
-    ValueChanged<String?>? onChanged,
-    ValueTransformer<String?>? valueTransformer,
-    bool enabled = true,
-    FormFieldSetter<String>? onSaved,
-    AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
-    VoidCallback? onReset,
-    FocusNode? focusNode,
+    super.decoration,
+    super.onChanged,
+    super.valueTransformer,
+    super.enabled,
+    super.onSaved,
+    super.autovalidateMode = AutovalidateMode.disabled,
+    super.onReset,
+    super.focusNode,
     this.maxLines = 1,
     this.obscureText = false,
     this.textCapitalization = TextCapitalization.none,
@@ -357,18 +356,7 @@ class FormBuilderTextField extends FormBuilderField<String> {
             'Obscured fields cannot be multiline.'),
         assert(maxLength == null || maxLength > 0),
         super(
-          key: key,
           initialValue: controller != null ? controller.text : initialValue,
-          name: name,
-          validator: validator,
-          valueTransformer: valueTransformer,
-          onChanged: onChanged,
-          autovalidateMode: autovalidateMode,
-          onSaved: onSaved,
-          enabled: enabled,
-          onReset: onReset,
-          decoration: decoration,
-          focusNode: focusNode,
           builder: (FormFieldState<String?> field) {
             final state = field as _FormBuilderTextFieldState;
             /*final effectiveDecoration = (decoration ?? const InputDecoration())

--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -79,7 +79,7 @@ class FormBuilder extends StatefulWidget {
   ///
   /// The [child] argument must not be null.
   const FormBuilder({
-    Key? key,
+    super.key,
     required this.child,
     this.onChanged,
     this.autovalidateMode,
@@ -89,7 +89,7 @@ class FormBuilder extends StatefulWidget {
     this.enabled = true,
     this.autoFocusOnValidationFailure = false,
     this.clearValueOnUnregister = false,
-  }) : super(key: key);
+  });
 
   static FormBuilderState? of(BuildContext context) =>
       context.findAncestorStateOfType<FormBuilderState>();

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -50,29 +50,20 @@ class FormBuilderField<T> extends FormField<T> {
 
   /// Creates a single form field.
   const FormBuilderField({
-    Key? key,
-    //From Super
-    FormFieldSetter<T>? onSaved,
-    T? initialValue,
-    AutovalidateMode autovalidateMode = AutovalidateMode.onUserInteraction,
-    bool enabled = true,
-    FormFieldValidator<T>? validator,
-    required FormFieldBuilder<T> builder,
+    super.key,
+    super.onSaved,
+    super.initialValue,
+    super.autovalidateMode = AutovalidateMode.onUserInteraction,
+    super.enabled = true,
+    super.validator,
+    required super.builder,
     required this.name,
     this.valueTransformer,
     this.onChanged,
     this.decoration = const InputDecoration(),
     this.onReset,
     this.focusNode,
-  }) : super(
-          key: key,
-          onSaved: onSaved,
-          initialValue: initialValue,
-          autovalidateMode: autovalidateMode,
-          enabled: enabled,
-          builder: builder,
-          validator: validator,
-        );
+  });
 
   @override
   FormBuilderFieldState<FormBuilderField<T>, T> createState() =>

--- a/lib/src/form_builder_field_option.dart
+++ b/lib/src/form_builder_field_option.dart
@@ -10,10 +10,10 @@ class FormBuilderFieldOption<T> extends StatelessWidget {
 
   /// Creates an option for fields with selection options
   const FormBuilderFieldOption({
-    Key? key,
+    super.key,
     required this.value,
     this.child,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/options/form_builder_chip_option.dart
+++ b/lib/src/options/form_builder_chip_option.dart
@@ -10,15 +10,11 @@ class FormBuilderChipOption<T> extends FormBuilderFieldOption<T> {
 
   /// Creates an option for fields with selection options
   const FormBuilderChipOption({
-    Key? key,
-    required value,
+    super.key,
+    required super.value,
     this.avatar,
-    child,
-  }) : super(
-          key: key,
-          value: value,
-          child: child,
-        );
+    super.child,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/grouped_checkbox.dart
+++ b/lib/src/widgets/grouped_checkbox.dart
@@ -181,7 +181,7 @@ class GroupedCheckbox<T> extends StatelessWidget {
   final ControlAffinity controlAffinity;
 
   const GroupedCheckbox({
-    Key? key,
+    super.key,
     required this.options,
     required this.orientation,
     required this.onChanged,
@@ -203,7 +203,7 @@ class GroupedCheckbox<T> extends StatelessWidget {
     this.wrapVerticalDirection = VerticalDirection.down,
     this.separator,
     this.controlAffinity = ControlAffinity.leading,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
Simplify code and improve readability by leveraging dart 2.17 super.initializers.

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [ ] Check the original issue to confirm it is fully satisfied
- [ ] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme
