### PR TITLE
Add widget tests for FormBuilderRangeSlider #1090

### DIFF
--- a/lib/src/fields/form_builder_range_slider.dart
+++ b/lib/src/fields/form_builder_range_slider.dart
@@ -136,7 +136,9 @@ class FormBuilderRangeSlider extends FormBuilderField<RangeValues> {
   }) : super(builder: (FormFieldState<RangeValues?> field) {
           final state = field as _FormBuilderRangeSliderState;
           final effectiveNumberFormat = numberFormat ?? NumberFormat.compact();
-
+          if (initialValue == null) {
+            field.setValue(RangeValues(min, min));
+          }
           return InputDecorator(
             decoration: state.decoration,
             child: Container(
@@ -145,7 +147,7 @@ class FormBuilderRangeSlider extends FormBuilderField<RangeValues> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   RangeSlider(
-                    values: field.value ?? RangeValues(min, min),
+                    values: field.value!,
                     min: min,
                     max: max,
                     divisions: divisions,

--- a/test/form_builder_range_slider_test.dart
+++ b/test/form_builder_range_slider_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'form_builder_tester.dart';
+
+void main() {
+  group('FormBuilderRangeSlider --', () {
+    testWidgets('basic', (WidgetTester tester) async {
+      const widgetName = 'formBuilderRangeSlider';
+      final testWidget = FormBuilderRangeSlider(
+        name: widgetName,
+        min: 10.0,
+        max: 20.0,
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+      expect(formSave(), isTrue);
+      expect(formValue<RangeValues?>(widgetName),
+          equals(const RangeValues(10.0, 10.0)));
+
+      // Inspired by https://github.com/flutter/flutter/blob/master/packages/flutter/test/material/range_slider_test.dart
+      // Tap at the center of the slider.
+      final Offset topLeft =
+          tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
+      final Offset bottomRight =
+          tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
+      final Offset rightTarget = topLeft + (bottomRight - topLeft) * 0.5;
+      await tester.tapAt(rightTarget);
+
+      expect(formSave(), isTrue);
+      expect(formValue<RangeValues>(widgetName), const RangeValues(10.0, 15.0));
+    });
+
+    testWidgets('initial value', (WidgetTester tester) async {
+      const widgetName = 'formBuilderRangeSlider';
+      final testWidget = FormBuilderRangeSlider(
+        name: widgetName,
+        min: 10.0,
+        max: 20.0,
+        initialValue: const RangeValues(14.0, 18.0),
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+      expect(formSave(), isTrue);
+      expect(formValue<RangeValues?>(widgetName),
+          equals(const RangeValues(14.0, 18.0)));
+
+      // Inspired by https://github.com/flutter/flutter/blob/master/packages/flutter/test/material/range_slider_test.dart
+      // Tap a small offset after the start of the slider.
+      final Offset topLeft =
+          tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
+      final Offset bottomRight =
+          tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
+      final Offset leftTarget = topLeft + (bottomRight - topLeft) * 0.1;
+      await tester.tapAt(leftTarget);
+
+      expect(formSave(), isTrue);
+      expect(formValue<RangeValues>(widgetName), const RangeValues(11.0, 18.0));
+    });
+  });
+}


### PR DESCRIPTION
I started working on  #1090 and I found out that when FormBuilderRangeSlider was used with the minimum parameters.
This exception was thrown:

`══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
The following _CastError was thrown building FormBuilderRangeSlider(dirty, dependencies:
[UnmanagedRestorationScope, _FormScope], state: _FormBuilderRangeSliderState#d5732):
Null check operator used on a null value`

The null operator was used on field.value.

## Solution
` if (initialValue == null) {
            field.setValue(RangeValues(min, min));
          }`


## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
