### PR TITLE
FormBuilderFields Type Alias

### DIFF
--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -107,7 +107,7 @@ class FormBuilderState extends State<FormBuilder> {
 
   bool get enabled => widget.enabled;
 
-  final _fields = <String, FormBuilderFieldState>{};
+  final FormBuilderFields _fields = {};
 
   //because dart type system will not accept ValueTransformer<dynamic>
   final _transformers = <String, Function>{};
@@ -126,7 +126,7 @@ class FormBuilderState extends State<FormBuilder> {
   /// Returns values after saving
   Map<String, dynamic> get initialValue => widget.initialValue;
 
-  Map<String, FormBuilderFieldState> get fields => _fields;
+  FormBuilderFields get fields => _fields;
 
   dynamic transformValue<T>(String name, T? v) {
     final t = _transformers[name];

--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -98,6 +98,10 @@ class FormBuilder extends StatefulWidget {
   FormBuilderState createState() => FormBuilderState();
 }
 
+/// A type alias for a map of form fields.
+typedef FormBuilderFields<T>
+    = Map<String, FormBuilderFieldState<FormBuilderField<T>, T>>;
+
 class FormBuilderState extends State<FormBuilder> {
   final _formKey = GlobalKey<FormState>();
 

--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -99,8 +99,8 @@ class FormBuilder extends StatefulWidget {
 }
 
 /// A type alias for a map of form fields.
-typedef FormBuilderFields<T>
-    = Map<String, FormBuilderFieldState<FormBuilderField<T>, T>>;
+typedef FormBuilderFields
+    = Map<String, FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>>;
 
 class FormBuilderState extends State<FormBuilder> {
   final _formKey = GlobalKey<FormState>();


### PR DESCRIPTION
## Solution description

In most cases, the type is inferred when `FormBuilderState.fields` is assigned to a variable. An example:

```dart
// the type is inferred.
final fields = _formKey.currentState?.fields;
```

However, when the dev needs to pass the reference of fields to a function, closure definition, constructor etc., they have to explicitly define its type. Currently, the type for `FormBuilderState.fields` is `Map<String, FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>>`. So, consider the simple function (which might also be taken as an event definition in BLoC) which needs to take fields as input:

```dart
void logIn({required Map<String, FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>> fields}) {
  // or Map<String, FormBuilderFieldState<FormBuilderField, dynamic>>
  // assuming fields have `email` and `password` fields...
  // ...which will be used to log in using Firebase
}
```

So, instead of having this long type definition, we can use `typedef` to create an alias, which is the primary purpose of this PR. So, new `logIn` function would be:


```dart
void logIn({required FormBuilderFields fields}) {
  // ...
}
```

Pros:

 - Shorter

Cons (that I can think of):

 - There's also a class named `FormBuilderField` in the library, might lead to confusion or misuse.

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] If apply, add documentation to code properties and package readme
