### PR TITLE
WIP: Implement Streams for Forms

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -74,6 +74,23 @@ class _CompleteFormState extends State<CompleteForm> {
                 child: Column(
                   children: <Widget>[
                     const SizedBox(height: 15),
+                    StreamBuilder(
+                      stream: _formKey.currentState!.onChanged,
+                      builder:
+                          (context, AsyncSnapshot<FormBuilderFields> snapshot) {
+                        if (snapshot.hasData) {
+                          final data = snapshot.data;
+
+                          return Column(
+                            children: data!.entries
+                                .map((e) => Text('${e.key}: ${e.value.value}'))
+                                .toList(),
+                          );
+                        }
+
+                        return const Text('no data');
+                      },
+                    ),
                     FormBuilderDateTimePicker(
                       name: 'date',
                       initialEntryMode: DatePickerEntryMode.calendar,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -61,6 +61,7 @@ class _CompleteFormState extends State<CompleteForm> {
                 onChanged: () {
                   _formKey.currentState!.save();
                   debugPrint(_formKey.currentState!.value.toString());
+                  setState(() {});
                 },
                 autovalidateMode: AutovalidateMode.disabled,
                 initialValue: const {
@@ -75,7 +76,7 @@ class _CompleteFormState extends State<CompleteForm> {
                   children: <Widget>[
                     const SizedBox(height: 15),
                     StreamBuilder(
-                      stream: _formKey.currentState!.onChanged,
+                      stream: _formKey.currentState?.onChanged,
                       builder:
                           (context, AsyncSnapshot<FormBuilderFields> snapshot) {
                         if (snapshot.hasData) {

--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -128,6 +128,9 @@ class FormBuilderState extends State<FormBuilder> {
 
   FormBuilderFields get fields => _fields;
 
+  // TODO add docs
+  Stream<FormBuilderFields> get onChanged => throw UnimplementedError();
+
   dynamic transformValue<T>(String name, T? v) {
     final t = _transformers[name];
     return t != null ? t.call(v) : v;

--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:developer';
 
 import 'package:flutter/material.dart';
@@ -113,6 +114,7 @@ class FormBuilderState extends State<FormBuilder> {
   final _transformers = <String, Function>{};
   final _instantValue = <String, dynamic>{};
   final _savedValue = <String, dynamic>{};
+  final _onChangedStreamController = StreamController<FormBuilderFields>();
 
   Map<String, dynamic> get instantValue =>
       Map<String, dynamic>.unmodifiable(_instantValue.map((key, value) =>
@@ -129,7 +131,7 @@ class FormBuilderState extends State<FormBuilder> {
   FormBuilderFields get fields => _fields;
 
   // TODO add docs
-  Stream<FormBuilderFields> get onChanged => throw UnimplementedError();
+  Stream<FormBuilderFields> get onChanged => _onChangedStreamController.stream;
 
   dynamic transformValue<T>(String name, T? v) {
     final t = _transformers[name];
@@ -152,6 +154,7 @@ class FormBuilderState extends State<FormBuilder> {
       setState(() {});
     }
     widget.onChanged?.call();
+    _onChangedStreamController.add(fields);
   }
 
   bool get isValid =>
@@ -165,6 +168,7 @@ class FormBuilderState extends State<FormBuilder> {
     if (isSetState) {
       setState(() {});
     }
+    _onChangedStreamController.add(fields);
   }
 
   void registerField(String name, FormBuilderFieldState field) {
@@ -195,6 +199,7 @@ class FormBuilderState extends State<FormBuilder> {
         populateForm: false,
       );
     }
+    _onChangedStreamController.add(fields);
   }
 
   void unregisterField(String name, FormBuilderFieldState field) {
@@ -219,6 +224,7 @@ class FormBuilderState extends State<FormBuilder> {
         return true;
       }());
     }
+    _onChangedStreamController.add(fields);
   }
 
   void save() {
@@ -271,6 +277,12 @@ class FormBuilderState extends State<FormBuilder> {
     val.forEach((key, dynamic value) {
       _fields[key]?.didChange(value);
     });
+  }
+
+  @override
+  void dispose() {
+    _onChangedStreamController.close();
+    super.dispose();
   }
 
   @override

--- a/test/form_builder_stream_test.dart
+++ b/test/form_builder_stream_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'form_builder_tester.dart';
+
+void main() {
+  group('onChanged --', () {
+    testWidgets('initial', (WidgetTester tester) async {
+      final key = GlobalKey<FormBuilderState>();
+      final form = FormBuilder(
+        key: key,
+        child: FormBuilderTextField(
+          key: const Key('text1'),
+          name: 'text1',
+        ),
+      );
+
+      await tester.pumpWidget(buildTestableFieldWidget(form));
+      final nextChange = await key.currentState!.onChanged.first;
+
+      expect(nextChange, contains('text1'));
+      expect(nextChange['text1']?.value, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #1155 

## Solution description

`FormBuilderState` now has a `StreamSubscription` named `onChanged` so that people can subscribe to the stream of changes and react to the changes.

This PR is a WIP (work-in-progress) and *should not be merged yet*.

 - Devs can use `_formKey.currentState!.onChanged.listen((FormBuilderFields fields) {})` to listen to the form changes.
 - Devs can use `_formKey.currentState!.onChanged.cancel()` to dispose of the stream.
 - A *very primitive* example has been implemented, but is subject to change. See the video below.
 - I have no idea as to how to test the streams. I have been trying to test it for a week now and cannot do so. That is the main reason why I don't want this feature to be merged. Let me first figure out a way to test the streams. The example works like a charm, though.

## Screenshots or Videos

https://user-images.githubusercontent.com/2399084/205637854-38e66db1-95b1-435d-93ed-2516b36b1c3a.mp4

This is what I added in example project, which is not very elegant to look at. I will refactor this later on. This is only for demo purposes.

As you can see, `StreamBuilder` reacts to the changes live and re-renders each time the form is updated.

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [ ] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme