### PR TITLE
feat(ui)!: provide magnifier configuration parameter to form builder text field

### DIFF
--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -284,6 +284,13 @@ class FormBuilderTextField extends FormBuilderField<String> {
   /// {@macro flutter.services.autofill.autofillHints}
   final Iterable<String>? autofillHints;
 
+  ///{@macro flutter.widgets.text_selection.TextMagnifierConfiguration.intro}
+  ///
+  ///{@macro flutter.widgets.magnifier.intro}
+  ///
+  ///{@macro flutter.widgets.text_selection.TextMagnifierConfiguration.details}
+  final TextMagnifierConfiguration? magnifierConfiguration;
+
   /// Creates a Material Design text field input.
   FormBuilderTextField({
     super.key,
@@ -341,6 +348,7 @@ class FormBuilderTextField extends FormBuilderField<String> {
     this.autofillHints,
     this.obscuringCharacter = '•',
     this.mouseCursor,
+    this.magnifierConfiguration,
   })  : assert(initialValue == null || controller == null),
         assert(minLines == null || minLines > 0),
         assert(maxLines == null || maxLines > 0),
@@ -409,6 +417,7 @@ class FormBuilderTextField extends FormBuilderField<String> {
               mouseCursor: mouseCursor,
               obscuringCharacter: obscuringCharacter,
               autofillHints: autofillHints,
+              magnifierConfiguration: magnifierConfiguration,
             );
           },
         );

--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -73,12 +73,14 @@ class FormBuilderTextField extends FormBuilderField<String> {
   /// {@macro flutter.widgets.editableText.expands}
   final bool expands;
 
-  /// Configuration of toolbar options.
+  /// {@macro flutter.widgets.EditableText.contextMenuBuilder}
   ///
-  /// If not set, select all and paste will default to be enabled. Copy and cut
-  /// will be disabled if [obscureText] is true. If [readOnly] is true,
-  /// paste and cut will be disabled regardless.
-  final ToolbarOptions? toolbarOptions;
+  /// If not provided, will build a default menu based on the platform.
+  ///
+  /// See also:
+  ///
+  ///  * [AdaptiveTextSelectionToolbar], which is built by default.
+  final EditableTextContextMenuBuilder? contextMenuBuilder;
 
   /// {@macro flutter.widgets.editableText.showCursor}
   final bool? showCursor;
@@ -343,11 +345,11 @@ class FormBuilderTextField extends FormBuilderField<String> {
     this.selectionWidthStyle = ui.BoxWidthStyle.tight,
     this.smartDashesType,
     this.smartQuotesType,
-    this.toolbarOptions,
     this.selectionHeightStyle = ui.BoxHeightStyle.tight,
     this.autofillHints,
     this.obscuringCharacter = '•',
     this.mouseCursor,
+    this.contextMenuBuilder,
     this.magnifierConfiguration,
   })  : assert(initialValue == null || controller == null),
         assert(minLines == null || minLines > 0),
@@ -413,8 +415,8 @@ class FormBuilderTextField extends FormBuilderField<String> {
               selectionWidthStyle: selectionWidthStyle,
               smartDashesType: smartDashesType,
               smartQuotesType: smartQuotesType,
-              toolbarOptions: toolbarOptions,
               mouseCursor: mouseCursor,
+              contextMenuBuilder: contextMenuBuilder,
               obscuringCharacter: obscuringCharacter,
               autofillHints: autofillHints,
               magnifierConfiguration: magnifierConfiguration,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-form-builder-ecosystem/flutter_form_build
 issue_tracker: https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/issues
 
 environment:
-  sdk: ">=2.19.0 <3.0.0"
-  flutter: ">=3.7.0"
+  sdk: ">2.18.9 <3.0.0"
+  flutter: ">3.6.9"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-form-builder-ecosystem/flutter_form_build
 issue_tracker: https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/issues
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.19.0 <3.0.0"
+  flutter: ">=3.7.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Connection with issue(s)

Connected to Flutter SDK bug: https://github.com/flutter/flutter/issues/119711

## Solution description

In version 3.7 Flutter team [introduced](https://medium.com/flutter/whats-new-in-flutter-3-7-38cbea71133c) **Text magnifier** feature, however, did not provide a way how to disable it globally. But this feature has [bugs](https://github.com/flutter/flutter/issues/119711) related to scrollable widgets. As a workaround, there is an option to provide [magnifierConfiguration](https://github.com/flutter/flutter/pull/107477) to `TextField`/`EditableText` widgets. Since `FormBuilderTextField` is using `TextField` under the hood there was no way how to provide this configuration to `FormBuilderTextField`, this PR fixes this issue.

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] If apply, add documentation to code properties and package readme
