### PR TITLE
Made FormBuilderTextField support context menu by default.

### DIFF
--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -349,7 +349,7 @@ class FormBuilderTextField extends FormBuilderField<String> {
     this.autofillHints,
     this.obscuringCharacter = '•',
     this.mouseCursor,
-    this.contextMenuBuilder,
+    this.contextMenuBuilder = _defaultContextMenuBuilder,
     this.magnifierConfiguration,
   })  : assert(initialValue == null || controller == null),
         assert(minLines == null || minLines > 0),
@@ -423,6 +423,15 @@ class FormBuilderTextField extends FormBuilderField<String> {
             );
           },
         );
+
+  static Widget _defaultContextMenuBuilder(
+    BuildContext context,
+    EditableTextState editableTextState,
+  ) {
+    return AdaptiveTextSelectionToolbar.editableText(
+      editableTextState: editableTextState,
+    );
+  }
 
   @override
   FormBuilderFieldState<FormBuilderTextField, String> createState() =>


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #1204 #1194

## Solution description
Quoting from #1194:

> Currently, default value for contextMenuBuilder parameter of FormBuilderTextBox is [not specified](https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/blob/4c83c5c9f8d235d29db2045620b6d656814ebc13/lib/src/fields/form_builder_text_field.dart#L352), so no context menu is shown as default.
In contrast, native TextFormField [specifies](https://github.com/flutter/flutter/blob/1d17caed66641b55a8e8faadf212398f746f8861/packages/flutter/lib/src/material/text_form_field.dart#L156) [default implementation](https://github.com/flutter/flutter/blob/1d17caed66641b55a8e8faadf212398f746f8861/packages/flutter/lib/src/material/text_form_field.dart#L250-L254) using AdaptiveTextSelectionToolbar.editableText.
It is great if FormBuilderTextField also support default context menu.
> 
> For your reference, the default context menu enables pasting from clipboard, selecting all inputs if there are any inputs, and cutting and copying seleted texts. I think these functions are "must-have" for UX.

Simply, because of that, no context menu was showing for the ```FormBuilderTextField``` widget.

### Solution
I simply used the same approach used by flutter's ```TextField``` widget. I first created a static method that provides us with the default context menu widget:
```dart
static Widget _defaultContextMenuBuilder(
  BuildContext context,
  EditableTextState editableTextState,
) {
  return AdaptiveTextSelectionToolbar.editableText(
    editableTextState: editableTextState,
  );
}
```
And the I used that as a default value for ```FormBuilderTextField.```:
```dart
FormBuilderTextField({
  super.key,
  required super.name,
  // ...
  this.contextMenuBuilder = _defaultContextMenuBuilder,
  // ...
```
## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
