### PR TITLE
Add optional param to FormBuilderFields invalidate method to skip requesting focus

### DIFF
--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -226,10 +226,14 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
     Scrollable.ensureVisible(context);
   }
 
-  void invalidate(String errorText) {
+  /// Invalidate this field using the given [errorText] string.
+  /// Request focus after invalidating (or skip it by setting [shouldRequestFocus] to false)
+  void invalidate(String errorText, {bool shouldRequestFocus = true}) {
     setState(() => _customErrorText = errorText);
     validate(clearCustomError: false);
-    requestFocus();
+    if(shouldRequestFocus) {
+      requestFocus();
+    }
   }
 
   InputDecoration get decoration => widget.decoration.copyWith(


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #955 

## Solution description
I added an optional param to the invalidate() method so it can be called without requesting focus.

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
