### PR TITLE
Improve focus and scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,44 +12,50 @@ Also included are common ready-made form input fields for FormBuilder. This give
 ___
 
 - [Features](#features)
-- [Inputs](#inpus)
-    - [Parameters](#parameters)
+- [Inputs](#inputs)
+  - [Parameters](#parameters)
 - [Use](#use)
-    - [Setup](#setup)
-    - [Basic use](#basic-use)
-    - [Specific uses](#specific-uses)
+  - [Setup](#setup)
+  - [Basic use](#basic-use)
+  - [Specific uses](#specific-uses)
+    - [Building your own custom field](#building-your-own-custom-field)
+    - [Programmatically changing field value](#programmatically-changing-field-value)
+    - [Programmatically inducing an error](#programmatically-inducing-an-error)
+    - [Conditional validation](#conditional-validation)
+    - [Implement reset, clear or other button into field](#implement-reset-clear-or-other-button-into-field)
 - [Support](#support)
-    - [Contribute](#contribute)
-    - [Questions and answers](#questions-and-answers)
-    - [Donations](#donations)
+  - [Contribute](#contribute)
+  - [Questions and answers](#questions-and-answers)
+  - [Donations](#donations)
 - [Roadmap](#roadmap)
 - [Ecosystem](#ecosystem)
 - [Thanks to](#thanks-to)
-    - [Contributors](#contributors)
+  - [Contributors](#contributors)
 
 ## Features
 
 - Create a form with several type of inputs
 - Get values from form by easy way
 - Apply validators to inputs fields
-- React to form fields changes and validations 
+- React to form fields changes and validations
 
 ## Inputs
 
 The currently supported fields include:
-* `FormBuilderCheckbox` - Single checkbox field
-* `FormBuilderCheckboxGroup` - List of checkboxes for multiple selection
-* `FormBuilderChoiceChip` - Creates a chip that acts like a radio button.
-* `FormBuilderDateRangePicker` - For selection of a range of dates
-* `FormBuilderDateTimePicker` - For `Date`, `Time` and `DateTime` input
-* `FormBuilderDropdown` - Used to select one value from a list as a Dropdown
-* `FormBuilderFilterChip` - Creates a chip that acts like a checkbox
-* `FormBuilderRadioGroup` - Used to select one value from a list of Radio Widgets
-* `FormBuilderRangeSlider` - Used to select a range from a range of values
-* `FormBuilderSegmentedControl` - For selection of a value using the `CupertinoSegmentedControl` widget as an input
-* `FormBuilderSlider` - For selection of a numerical value on a slider
-* `FormBuilderSwitch` - On/Off switch field
-* `FormBuilderTextField` - A Material Design text field input
+
+- `FormBuilderCheckbox` - Single checkbox field
+- `FormBuilderCheckboxGroup` - List of checkboxes for multiple selection
+- `FormBuilderChoiceChip` - Creates a chip that acts like a radio button.
+- `FormBuilderDateRangePicker` - For selection of a range of dates
+- `FormBuilderDateTimePicker` - For `Date`, `Time` and `DateTime` input
+- `FormBuilderDropdown` - Used to select one value from a list as a Dropdown
+- `FormBuilderFilterChip` - Creates a chip that acts like a checkbox
+- `FormBuilderRadioGroup` - Used to select one value from a list of Radio Widgets
+- `FormBuilderRangeSlider` - Used to select a range from a range of values
+- `FormBuilderSegmentedControl` - For selection of a value using the `CupertinoSegmentedControl` widget as an input
+- `FormBuilderSlider` - For selection of a numerical value on a slider
+- `FormBuilderSwitch` - On/Off switch field
+- `FormBuilderTextField` - A Material Design text field input
 
 ### Parameters
 
@@ -161,7 +167,7 @@ _formKey.currentState.patchValue({
 
 #### Programmatically inducing an error
 
-##### Option 1 - Using FormBuilder / FieldBuilderField key
+##### Using form state key or field state key
 
 ```dart
 final _formKey = GlobalKey<FormBuilderState>();
@@ -185,11 +191,9 @@ FormBuilder(
         onPressed: () async {
           if(await checkIfEmailExists()){
             // Either invalidate using Form Key
-            _formKey.currentState?.invalidateField(
-                name: 'email', errorText: 'Email already taken.');
+            _formKey.currentState?.fields['email']?.invalidate('Email already taken');
             // OR invalidate using Field Key
-            _emailFieldKey.currentState
-                ?.invalidate('Email already taken');
+            _emailFieldKey.currentState?.invalidate('Email already taken');
           }
         },
       ),
@@ -198,15 +202,20 @@ FormBuilder(
 ),
 ```
 
-##### Option 2 - Using InputDecoration.errorText
+When use `invalidate` and `validate` methods, can use two optional parameters configure the behavior
+when invalidate field or form, like focus or auto scroll. Take a look on method documentation for more details
+
+##### Using InputDecoration.errorText
 
 Declare a variable to hold your error:
-```Dart
+
+```dart
 String _emailError;
 ```
 
 Use the variable as the `errorText` within `InputDecoration`
-```Dart
+
+```dart
 FormBuilderTextField(
   name: 'email',
   decoration: InputDecoration(
@@ -221,7 +230,8 @@ FormBuilderTextField(
 ```
 
 Set the error text
-```Dart
+
+```dart
 RaisedButton(
   child: Text('Submit'),
   onPressed: () async {
@@ -268,7 +278,7 @@ FormBuilderRadioGroup(
   ),
 ```
 
-#### Implement reset, clear or other button into FormBuilderField
+#### Implement reset, clear or other button into field
 
 If you can add some button to reset specific field, can use the `decoration` parameter like this:
 
@@ -325,9 +335,9 @@ FormBuilderTextField(
 
 You have some ways to contribute to this packages
 
- - Beginner: Reporting bugs or request new features
- - Intermediate: Implement new features (from issues or not) and created pull requests
- - Advanced: Join to [organization](#ecosystem) like a member and help coding, manage issues, dicuss new features and other things
+- Beginner: Reporting bugs or request new features
+- Intermediate: Implement new features (from issues or not) and created pull requests
+- Advanced: Join to [organization](#ecosystem) like a member and help coding, manage issues, dicuss new features and other things
 
  See [contribution file](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md) for more details
 
@@ -343,8 +353,6 @@ Donate or become a sponsor of Flutter Form Builder Ecosystem
 
 ## Roadmap
 
-- [Improve focus behavior](https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/issues/1049)
-- Add more widget tests and missing tests for some fields: [#1090](https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/issues/1090)/[#1089](https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/issues/1089)
 - [Add visual examples](https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/issues/1027) (images, gifs, videos, sample application)
 - [Solve open issues](https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/issues), [prioritizing bugs](https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/labels/bug)
 

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -171,6 +171,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -185,6 +186,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -272,7 +274,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -346,7 +348,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -395,7 +397,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -43,5 +43,7 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       localizationsDelegates: [
         FormBuilderLocalizations.delegate,
-        GlobalMaterialLocalizations.delegate,
+        ...GlobalMaterialLocalizations.delegates,
         GlobalWidgetsLocalizations.delegate,
       ],
       supportedLocales: FormBuilderLocalizations.supportedLocales,
@@ -199,7 +199,6 @@ class _CompleteFormState extends State<CompleteForm> {
                       textInputAction: TextInputAction.next,
                     ),
                     FormBuilderDropdown<String>(
-                      // autovalidate: true,
                       name: 'gender',
                       decoration: InputDecoration(
                         labelText: 'Gender',

--- a/example/lib/sources/signup_form.dart
+++ b/example/lib/sources/signup_form.dart
@@ -111,8 +111,8 @@ class _SignupFormState extends State<SignupForm> {
                     if (_formKey.currentState?.saveAndValidate() ?? false) {
                       if (true) {
                         // Either invalidate using Form Key
-                        _formKey.currentState?.invalidateField(
-                            name: 'email', errorText: 'Email already taken.');
+                        _formKey.currentState?.fields['email']
+                            ?.invalidate('Email already taken.');
                         // OR invalidate using Field Key
                         // _emailFieldKey.currentState?.invalidate('Email already taken.');
                       }

--- a/lib/src/fields/form_builder_checkbox.dart
+++ b/lib/src/fields/form_builder_checkbox.dart
@@ -43,8 +43,6 @@ class FormBuilderCheckbox extends FormBuilderField<bool> {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
-  final bool shouldRequestFocus;
-
   /// If true the checkbox's [value] can be true, false, or null.
   ///
   /// Checkbox displays a dash when its value is null.
@@ -102,6 +100,7 @@ class FormBuilderCheckbox extends FormBuilderField<bool> {
     super.autovalidateMode = AutovalidateMode.disabled,
     super.onReset,
     super.focusNode,
+    super.restorationId,
     required this.title,
     this.activeColor,
     this.autofocus = false,
@@ -110,7 +109,6 @@ class FormBuilderCheckbox extends FormBuilderField<bool> {
     this.controlAffinity = ListTileControlAffinity.leading,
     this.secondary,
     this.selected = false,
-    this.shouldRequestFocus = false,
     this.subtitle,
     this.tristate = false,
     this.shape,
@@ -129,9 +127,6 @@ class FormBuilderCheckbox extends FormBuilderField<bool> {
                 value: tristate ? state.value : (state.value ?? false),
                 onChanged: state.enabled
                     ? (value) {
-                        if (shouldRequestFocus) {
-                          state.requestFocus();
-                        }
                         state.didChange(value);
                       }
                     : null,

--- a/lib/src/fields/form_builder_checkbox_group.dart
+++ b/lib/src/fields/form_builder_checkbox_group.dart
@@ -23,7 +23,6 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderField<List<T>> {
   final Widget? separator;
   final ControlAffinity controlAffinity;
   final OptionsOrientation orientation;
-  final bool shouldRequestFocus;
 
   /// Creates a list of Checkboxes for selecting multiple options
   FormBuilderCheckboxGroup({
@@ -39,6 +38,7 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderField<List<T>> {
     super.autovalidateMode = AutovalidateMode.disabled,
     super.onReset,
     super.focusNode,
+    super.restorationId,
     required this.options,
     this.activeColor,
     this.checkColor,
@@ -58,7 +58,6 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderField<List<T>> {
     this.separator,
     this.controlAffinity = ControlAffinity.leading,
     this.orientation = OptionsOrientation.wrap,
-    this.shouldRequestFocus = false,
   }) : super(
           builder: (FormFieldState<List<T>?> field) {
             final state = field as _FormBuilderCheckboxGroupState<T>;
@@ -70,9 +69,6 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderField<List<T>> {
                 value: state.value,
                 options: options,
                 onChanged: (val) {
-                  if (shouldRequestFocus) {
-                    state.requestFocus();
-                  }
                   field.didChange(val);
                 },
                 disabled: state.enabled

--- a/lib/src/fields/form_builder_choice_chips.dart
+++ b/lib/src/fields/form_builder_choice_chips.dart
@@ -3,8 +3,6 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 /// A list of `Chip`s that acts like radio buttons
 class FormBuilderChoiceChip<T> extends FormBuilderField<T> {
-  final bool shouldRequestFocus;
-
   /// The list of items the user can select.
   final List<FormBuilderChipOption<T>> options;
 
@@ -266,6 +264,10 @@ class FormBuilderChoiceChip<T> extends FormBuilderField<T> {
     required super.name,
     required this.options,
     super.initialValue,
+    super.restorationId,
+    super.onChanged,
+    super.valueTransformer,
+    super.onReset,
     this.alignment = WrapAlignment.start,
     this.avatarBorder = const CircleBorder(),
     this.backgroundColor,
@@ -284,14 +286,10 @@ class FormBuilderChoiceChip<T> extends FormBuilderField<T> {
     this.selectedShadowColor,
     this.shadowColor,
     this.shape,
-    this.shouldRequestFocus = false,
     this.spacing = 0.0,
     this.textDirection,
     this.verticalDirection = VerticalDirection.down,
     this.visualDensity,
-    super.onChanged,
-    super.valueTransformer,
-    super.onReset,
   }) : super(builder: (FormFieldState<T?> field) {
           final state = field as _FormBuilderChoiceChipState<T>;
 
@@ -315,9 +313,6 @@ class FormBuilderChoiceChip<T> extends FormBuilderField<T> {
                     onSelected: state.enabled
                         ? (selected) {
                             final choice = selected ? option.value : null;
-                            if (shouldRequestFocus) {
-                              state.requestFocus();
-                            }
                             state.didChange(choice);
                           }
                         : null,

--- a/lib/src/fields/form_builder_date_range_picker.dart
+++ b/lib/src/fields/form_builder_date_range_picker.dart
@@ -76,6 +76,7 @@ class FormBuilderDateRangePicker extends FormBuilderField<DateTimeRange> {
     super.autovalidateMode = AutovalidateMode.disabled,
     super.onReset,
     super.focusNode,
+    super.restorationId,
     required this.firstDate,
     required this.lastDate,
     this.format,
@@ -120,7 +121,6 @@ class FormBuilderDateRangePicker extends FormBuilderField<DateTimeRange> {
     this.fieldStartHintText,
     this.fieldStartLabelText,
     this.helpText,
-    // this.initialDateRange,
     this.initialEntryMode = DatePickerEntryMode.calendar,
     this.routeSettings,
     this.saveText,
@@ -277,7 +277,7 @@ class _FormBuilderDateRangePickerState
               padding: EdgeInsets.zero,
               constraints: const BoxConstraints(maxWidth: 24, maxHeight: 24),
               onPressed: () {
-                requestFocus();
+                focus();
                 didChange(null);
                 effectiveFocusNode.unfocus();
               },

--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -139,6 +139,7 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
     super.autovalidateMode = AutovalidateMode.disabled,
     super.onReset,
     super.focusNode,
+    super.restorationId,
     this.inputType = InputType.both,
     this.scrollPadding = const EdgeInsets.all(20.0),
     this.cursorWidth = 2.0,

--- a/lib/src/fields/form_builder_dropdown.dart
+++ b/lib/src/fields/form_builder_dropdown.dart
@@ -15,13 +15,6 @@ class FormBuilderDropdown<T> extends FormBuilderField<T> {
   /// the [decoration.hint] widget will be displayed instead.
   final List<DropdownMenuItem<T>> items;
 
-  /// A placeholder widget that is displayed by the dropdown button.
-  ///
-  /// If [value] is null, this widget is displayed as a placeholder for
-  /// the dropdown button's value. This widget is also displayed if the button
-  /// is disabled ([items] or [onChanged] is null) and [disabledHint] is null.
-  final Widget? hint;
-
   /// A message to show when the dropdown is disabled.
   ///
   /// Displayed if [items] or [onChanged] is null. If [decoration.hint] and
@@ -179,9 +172,6 @@ class FormBuilderDropdown<T> extends FormBuilderField<T> {
   /// instead.
   final Color? dropdownColor;
 
-  final bool allowClear;
-  final Widget clearIcon;
-
   /// The maximum height of the menu.
   ///
   /// The maximum height of the menu must be at least one row shorter than
@@ -192,8 +182,6 @@ class FormBuilderDropdown<T> extends FormBuilderField<T> {
   /// mentioned above, then the menu defaults to being padded at the top
   /// and bottom of the menu by at one menu item's height.
   final double? menuMaxHeight;
-
-  final bool shouldRequestFocus;
 
   /// Whether detected gestures should provide acoustic and/or haptic feedback.
   ///
@@ -241,25 +229,19 @@ class FormBuilderDropdown<T> extends FormBuilderField<T> {
     super.autovalidateMode = AutovalidateMode.disabled,
     super.onReset,
     super.focusNode,
+    super.restorationId,
     required this.items,
     this.isExpanded = true,
     this.isDense = true,
     this.elevation = 8,
     this.iconSize = 24.0,
-    @Deprecated('Please use decoration.hint and variations to set your desired label')
-        this.hint,
     this.style,
     this.disabledHint,
     this.icon,
     this.iconDisabledColor,
     this.iconEnabledColor,
-    @Deprecated('Please use decoration.suffix to set your desired behavior')
-        this.allowClear = false,
-    @Deprecated('Please use decoration.suffixIcon to set your desired icon')
-        this.clearIcon = const Icon(Icons.close),
     this.onTap,
     this.autofocus = false,
-    this.shouldRequestFocus = false,
     this.dropdownColor,
     this.focusColor,
     this.itemHeight,
@@ -273,9 +255,6 @@ class FormBuilderDropdown<T> extends FormBuilderField<T> {
             final state = field as _FormBuilderDropdownState<T>;
 
             void changeValue(T? value) {
-              if (shouldRequestFocus) {
-                state.requestFocus();
-              }
               state.didChange(value);
             }
 
@@ -285,7 +264,6 @@ class FormBuilderDropdown<T> extends FormBuilderField<T> {
               child: DropdownButtonHideUnderline(
                 child: DropdownButton<T>(
                   isExpanded: isExpanded,
-                  hint: hint,
                   items: items,
                   value: field.value,
                   style: style,

--- a/lib/src/fields/form_builder_filter_chips.dart
+++ b/lib/src/fields/form_builder_filter_chips.dart
@@ -5,7 +5,6 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 /// Field with chips that acts like a list checkboxes.
 class FormBuilderFilterChip<T> extends FormBuilderField<List<T>> {
   //TODO: Add documentation
-  final bool shouldRequestFocus;
   final Color? backgroundColor;
   final Color? disabledColor;
   final Color? selectedColor;
@@ -45,6 +44,7 @@ class FormBuilderFilterChip<T> extends FormBuilderField<List<T>> {
     super.key,
     super.initialValue,
     required super.name,
+    super.restorationId,
     required this.options,
     this.alignment = WrapAlignment.start,
     this.avatarBorder = const CircleBorder(),
@@ -67,7 +67,6 @@ class FormBuilderFilterChip<T> extends FormBuilderField<List<T>> {
     this.selectedShadowColor,
     this.shadowColor,
     this.shape,
-    this.shouldRequestFocus = false,
     this.showCheckmark = true,
     this.spacing = 0.0,
     this.textDirection,
@@ -104,14 +103,10 @@ class FormBuilderFilterChip<T> extends FormBuilderField<List<T>> {
                                   fieldValue.contains(option.value))
                           ? (selected) {
                               final currentValue = [...fieldValue];
-                              if (selected) {
-                                currentValue.add(option.value);
-                              } else {
-                                currentValue.remove(option.value);
-                              }
-                              if (shouldRequestFocus) {
-                                state.requestFocus();
-                              }
+                              selected
+                                  ? currentValue.add(option.value)
+                                  : currentValue.remove(option.value);
+
                               field.didChange(currentValue);
                             }
                           : null,

--- a/lib/src/fields/form_builder_radio_group.dart
+++ b/lib/src/fields/form_builder_radio_group.dart
@@ -5,7 +5,6 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 /// Field to select one value from a list of Radio Widgets
 class FormBuilderRadioGroup<T> extends FormBuilderField<T> {
   final Axis wrapDirection;
-  final bool shouldRadioRequestFocus;
   final Color? activeColor;
   final Color? focusColor;
   final Color? hoverColor;
@@ -35,7 +34,6 @@ class FormBuilderRadioGroup<T> extends FormBuilderField<T> {
     required super.name,
     required this.options,
     super.initialValue,
-    this.shouldRadioRequestFocus = false,
     this.activeColor,
     this.controlAffinity = ControlAffinity.leading,
     this.disabled,
@@ -55,6 +53,7 @@ class FormBuilderRadioGroup<T> extends FormBuilderField<T> {
     super.onChanged,
     super.valueTransformer,
     super.onReset,
+    super.restorationId,
   }) : super(
           builder: (FormFieldState<T?> field) {
             final state = field as _FormBuilderRadioGroupState<T>;
@@ -71,9 +70,6 @@ class FormBuilderRadioGroup<T> extends FormBuilderField<T> {
                 hoverColor: hoverColor,
                 materialTapTargetSize: materialTapTargetSize,
                 onChanged: (value) {
-                  if (shouldRadioRequestFocus) {
-                    state.requestFocus();
-                  }
                   state.didChange(value);
                 },
                 options: options,

--- a/lib/src/fields/form_builder_range_slider.dart
+++ b/lib/src/fields/form_builder_range_slider.dart
@@ -102,7 +102,6 @@ class FormBuilderRangeSlider extends FormBuilderField<RangeValues> {
   final TextStyle? textStyle;
   final TextStyle? maxTextStyle;
   final NumberFormat? numberFormat;
-  final bool shouldRequestFocus;
 
   /// Creates field to select a range of values on a Slider
   FormBuilderRangeSlider({
@@ -132,7 +131,6 @@ class FormBuilderRangeSlider extends FormBuilderField<RangeValues> {
     this.textStyle,
     this.maxTextStyle,
     this.numberFormat,
-    this.shouldRequestFocus = false,
   }) : super(builder: (FormFieldState<RangeValues?> field) {
           final state = field as _FormBuilderRangeSliderState;
           final effectiveNumberFormat = numberFormat ?? NumberFormat.compact();
@@ -159,9 +157,6 @@ class FormBuilderRangeSlider extends FormBuilderField<RangeValues> {
                     semanticFormatterCallback: semanticFormatterCallback,
                     onChanged: state.enabled
                         ? (values) {
-                            if (shouldRequestFocus) {
-                              state.requestFocus();
-                            }
                             field.didChange(values);
                           }
                         : null,

--- a/lib/src/fields/form_builder_segmented_control.dart
+++ b/lib/src/fields/form_builder_segmented_control.dart
@@ -37,8 +37,6 @@ class FormBuilderSegmentedControl<T extends Object>
   /// The list of options the user can select.
   final List<FormBuilderFieldOption<T>> options;
 
-  final bool shouldRequestFocus;
-
   /// Creates field for selection of a value from the `CupertinoSegmentedControl`
   FormBuilderSegmentedControl({
     super.key,
@@ -53,13 +51,13 @@ class FormBuilderSegmentedControl<T extends Object>
     super.autovalidateMode = AutovalidateMode.disabled,
     super.onReset,
     super.focusNode,
+    super.restorationId,
     required this.options,
     this.borderColor,
     this.selectedColor,
     this.pressedColor,
     this.padding,
     this.unselectedColor,
-    this.shouldRequestFocus = false,
   }) : super(
           builder: (FormFieldState<T?> field) {
             final state = field as _FormBuilderSegmentedControlState<T>;
@@ -90,9 +88,6 @@ class FormBuilderSegmentedControl<T extends Object>
                   padding: padding,
                   unselectedColor: unselectedColor,
                   onValueChanged: (value) {
-                    if (shouldRequestFocus) {
-                      state.requestFocus();
-                    }
                     if (state.enabled) {
                       field.didChange(value);
                     } else {

--- a/lib/src/fields/form_builder_slider.dart
+++ b/lib/src/fields/form_builder_slider.dart
@@ -127,7 +127,6 @@ class FormBuilderSlider extends FormBuilderField<double> {
   final TextStyle? minTextStyle;
   final TextStyle? textStyle;
   final TextStyle? maxTextStyle;
-  final bool shouldRequestFocus;
 
   /// Creates field for selection of a numerical value on a slider
   FormBuilderSlider({
@@ -143,6 +142,7 @@ class FormBuilderSlider extends FormBuilderField<double> {
     super.autovalidateMode = AutovalidateMode.disabled,
     super.onReset,
     super.focusNode,
+    super.restorationId,
     required this.min,
     required this.max,
     this.divisions,
@@ -159,7 +159,6 @@ class FormBuilderSlider extends FormBuilderField<double> {
     this.maxTextStyle,
     this.autofocus = false,
     this.mouseCursor,
-    this.shouldRequestFocus = false,
   }) : super(
           builder: (FormFieldState<double?> field) {
             final state = field as _FormBuilderSliderState;
@@ -186,9 +185,6 @@ class FormBuilderSlider extends FormBuilderField<double> {
                       semanticFormatterCallback: semanticFormatterCallback,
                       onChanged: state.enabled
                           ? (value) {
-                              if (shouldRequestFocus) {
-                                state.requestFocus();
-                              }
                               field.didChange(value);
                             }
                           : null,

--- a/lib/src/fields/form_builder_switch.dart
+++ b/lib/src/fields/form_builder_switch.dart
@@ -76,8 +76,6 @@ class FormBuilderSwitch extends FormBuilderField<bool> {
   /// Normally, this property is left to its default value, false.
   final bool selected;
 
-  final bool shouldRequestFocus;
-
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
@@ -95,6 +93,7 @@ class FormBuilderSwitch extends FormBuilderField<bool> {
     super.autovalidateMode = AutovalidateMode.disabled,
     super.onReset,
     super.focusNode,
+    super.restorationId,
     required this.title,
     this.activeColor,
     this.activeTrackColor,
@@ -107,7 +106,6 @@ class FormBuilderSwitch extends FormBuilderField<bool> {
     this.controlAffinity = ListTileControlAffinity.trailing,
     this.contentPadding = EdgeInsets.zero,
     this.autofocus = false,
-    this.shouldRequestFocus = false,
     this.selected = false,
   }) : super(
           builder: (FormFieldState<bool?> field) {
@@ -123,9 +121,6 @@ class FormBuilderSwitch extends FormBuilderField<bool> {
                 value: state.value ?? false,
                 onChanged: state.enabled
                     ? (value) {
-                        if (shouldRequestFocus) {
-                          state.requestFocus();
-                        }
                         field.didChange(value);
                       }
                     : null,

--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -89,8 +89,8 @@ class FormBuilderTextField extends FormBuilderField<String> {
   /// part of the character counter is shown.
   static const int noMaxLength = -1;
 
-  /// The maximum number of characters (Unicode scalar values) to allow in the
-  /// text field.
+  /// The maximum number of characters (Unicode grapheme clusters) to allow in
+  /// the text field.
   ///
   /// If set, a character counter will be displayed below the
   /// field showing how many characters have been entered. If set to a number
@@ -98,9 +98,11 @@ class FormBuilderTextField extends FormBuilderField<String> {
   /// to [TextField.noMaxLength] then only the current character count is displayed.
   ///
   /// After [maxLength] characters have been input, additional input
-  /// is ignored, unless [maxLengthEnforced] is set to false. The text field
-  /// enforces the length with a [LengthLimitingTextInputFormatter], which is
-  /// evaluated after the supplied [inputFormatters], if any.
+  /// is ignored, unless [maxLengthEnforcement] is set to
+  /// [MaxLengthEnforcement.none].
+  ///
+  /// The text field enforces the length with a [LengthLimitingTextInputFormatter],
+  /// which is evaluated after the supplied [inputFormatters], if any.
   ///
   /// This value must be either null, [TextField.noMaxLength], or greater than 0.
   /// If null (the default) then there is no limit to the number of characters
@@ -110,36 +112,12 @@ class FormBuilderTextField extends FormBuilderField<String> {
   /// Whitespace characters (e.g. newline, space, tab) are included in the
   /// character count.
   ///
-  /// If [maxLengthEnforced] is set to false, then more than [maxLength]
-  /// characters may be entered, but the error counter and divider will
-  /// switch to the [decoration.errorStyle] when the limit is exceeded.
+  /// If [maxLengthEnforcement] is [MaxLengthEnforcement.none], then more than
+  /// [maxLength] characters may be entered, but the error counter and divider
+  /// will switch to the [decoration]'s [InputDecoration.errorStyle] when the
+  /// limit is exceeded.
   ///
-  /// ## Limitations
-  ///
-  /// The text field does not currently count Unicode grapheme clusters (i.e.
-  /// characters visible to the user), it counts Unicode scalar values, which
-  /// leaves out a number of useful possible characters (like many emoji and
-  /// composed characters), so this will be inaccurate in the presence of those
-  /// characters. If you expect to encounter these kinds of characters, be
-  /// generous in the maxLength used.
-  ///
-  /// For instance, the character "ö" can be represented as '\u{006F}\u{0308}',
-  /// which is the letter "o" followed by a composed diaeresis "¨", or it can
-  /// be represented as '\u{00F6}', which is the Unicode scalar value "LATIN
-  /// SMALL LETTER O WITH DIAERESIS". In the first case, the text field will
-  /// count two characters, and the second case will be counted as one
-  /// character, even though the user can see no difference in the input.
-  ///
-  /// Similarly, some emoji are represented by multiple scalar values. The
-  /// Unicode "THUMBS UP SIGN + MEDIUM SKIN TONE MODIFIER", "👍🏽", should be
-  /// counted as a single character, but because it is a combination of two
-  /// Unicode scalar values, '\u{1F44D}\u{1F3FD}', it is counted as two
-  /// characters.
-  ///
-  /// See also:
-  ///
-  ///  * [LengthLimitingTextInputFormatter] for more information on how it
-  ///    counts characters, and how it may differ from the intuitive meaning.
+  /// {@macro flutter.services.lengthLimitingTextInputFormatter.maxLength}
   final int? maxLength;
 
   final MaxLengthEnforcement? maxLengthEnforcement;
@@ -308,6 +286,7 @@ class FormBuilderTextField extends FormBuilderField<String> {
     super.autovalidateMode = AutovalidateMode.disabled,
     super.onReset,
     super.focusNode,
+    super.restorationId,
     this.maxLines = 1,
     this.obscureText = false,
     this.textCapitalization = TextCapitalization.none,
@@ -373,6 +352,7 @@ class FormBuilderTextField extends FormBuilderField<String> {
                 .applyDefaults(Theme.of(field.context).inputDecorationTheme);*/
 
             return TextField(
+              restorationId: restorationId,
               controller: state._effectiveController,
               focusNode: state.effectiveFocusNode,
               decoration: state.decoration,

--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -233,6 +233,11 @@ class FormBuilderState extends State<FormBuilder> {
   ///
   /// Auto scroll to first invalid field focused if [autoScrollWhenFocusOnInvalid] is `true`.
   /// By default `false`.
+  ///
+  /// Note: If a invalid field is from type **TextField** and will focused,
+  /// the form will auto scroll to show this invalid field.
+  /// In this case, the automatic scroll happens because is a behavior inside the framework,
+  /// not because [autoScrollWhenFocusOnInvalid] is `true`.
   bool validate({
     bool focusOnInvalid = true,
     bool autoScrollWhenFocusOnInvalid = false,
@@ -258,6 +263,11 @@ class FormBuilderState extends State<FormBuilder> {
   ///
   /// Auto scroll to first invalid field focused if [autoScrollWhenFocusOnInvalid] is `true`.
   /// By default `false`.
+  ///
+  /// Note: If a invalid field is from type **TextField** and will focused,
+  /// the form will auto scroll to show this invalid field.
+  /// In this case, the automatic scroll happens because is a behavior inside the framework,
+  /// not because [autoScrollWhenFocusOnInvalid] is `true`.
   bool saveAndValidate({
     bool focusOnInvalid = true,
     bool autoScrollWhenFocusOnInvalid = false,

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -214,6 +214,11 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   ///
   /// Auto scroll when focus invalid if [autoScrollWhenFocusOnInvalid] is `true`.
   /// By default `false`.
+  ///
+  /// Note: If a invalid field is from type **TextField** and will focused,
+  /// the form will auto scroll to show this invalid field.
+  /// In this case, the automatic scroll happens because is a behavior inside the framework,
+  /// not because [autoScrollWhenFocusOnInvalid] is `true`.
   @override
   bool validate({
     bool clearCustomError = true,
@@ -238,18 +243,23 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   /// Focus field if [shoudlFocus] is `true`.
   /// By default `true`
   ///
-  /// Auto scroll when focus invalid if [autoScrollWhenFocusOnInvalid] is `true`.
+  /// Auto scroll when focus invalid if [shouldAutoScrollWhenFocus] is `true`.
   /// By default `false`.
+  ///
+  /// Note: If a invalid field is from type **TextField** and will focused,
+  /// the form will auto scroll to show this invalid field.
+  /// In this case, the automatic scroll happens because is a behavior inside the framework,
+  /// not because [shouldAutoScrollWhenFocus] is `true`.
   void invalidate(
     String errorText, {
     bool shoudlFocus = true,
-    bool autoScrollWhenFocusOnInvalid = false,
+    bool shouldAutoScrollWhenFocus = false,
   }) {
     setState(() => _customErrorText = errorText);
 
     validate(
       clearCustomError: false,
-      autoScrollWhenFocusOnInvalid: autoScrollWhenFocusOnInvalid,
+      autoScrollWhenFocusOnInvalid: shouldAutoScrollWhenFocus,
       focusOnInvalid: shoudlFocus,
     );
   }

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -46,8 +46,6 @@ class FormBuilderField<T> extends FormField<T> {
   /// {@macro flutter.widgets.Focus.focusNode}
   final FocusNode? focusNode;
 
-  // TODO: implement bool autofocus, ValueChanged<bool> onValidated
-
   /// Creates a single form field.
   const FormBuilderField({
     super.key,
@@ -56,6 +54,7 @@ class FormBuilderField<T> extends FormField<T> {
     super.autovalidateMode = AutovalidateMode.onUserInteraction,
     super.enabled = true,
     super.validator,
+    super.restorationId,
     required super.builder,
     required this.name,
     this.valueTransformer,
@@ -157,26 +156,18 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
     super.dispose();
   }
 
-  // @override
-  // void save() {
-  //   _informFormForFieldChange(
-  //     isSetState: true,
-  //   );
-  //   super.save();
-  // }
-
-  void _informFormForFieldChange({required bool isSetState}) {
+  void _informFormForFieldChange() {
     if (_formBuilderState != null) {
       if (enabled || !_formBuilderState!.widget.skipDisabled) {
         _formBuilderState!.setInternalFieldValue<T>(
           widget.name,
           value,
-          isSetState: isSetState,
+          isSetState: false,
         );
       } else {
         _formBuilderState!.removeInternalFieldValue(
           widget.name,
-          isSetState: isSetState,
+          isSetState: false,
         );
       }
     }
@@ -192,14 +183,14 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   void setValue(T? value, {bool populateForm = true}) {
     super.setValue(value);
     if (populateForm) {
-      _informFormForFieldChange(isSetState: false);
+      _informFormForFieldChange();
     }
   }
 
   @override
   void didChange(T? value) {
     super.didChange(value);
-    _informFormForFieldChange(isSetState: false);
+    _informFormForFieldChange();
     widget.onChanged?.call(value);
   }
 
@@ -213,23 +204,62 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
     widget.onReset?.call();
   }
 
+  /// Validate field
+  ///
+  /// Clear custom error if [clearCustomError] is `true`.
+  /// By default `true`
+  ///
+  /// Focus when field is invalid if [focusOnInvalid] is `true`.
+  /// By default `true`
+  ///
+  /// Auto scroll when focus invalid if [autoScrollWhenFocusOnInvalid] is `true`.
+  /// By default `false`.
   @override
-  bool validate({bool clearCustomError = true}) {
+  bool validate({
+    bool clearCustomError = true,
+    bool focusOnInvalid = true,
+    bool autoScrollWhenFocusOnInvalid = false,
+  }) {
     if (clearCustomError) {
       setState(() => _customErrorText = null);
     }
-    return super.validate() && !hasError;
+    final isValid = super.validate() && !hasError;
+
+    if (!isValid && focusOnInvalid && enabled) {
+      focus();
+      if (autoScrollWhenFocusOnInvalid) ensureScrollableVisibility();
+    }
+
+    return isValid;
   }
 
-  void requestFocus() {
-    FocusScope.of(context).requestFocus(effectiveFocusNode);
-    Scrollable.ensureVisible(context);
-  }
-
-  void invalidate(String errorText) {
+  /// Invalidate field with a [errorText]
+  ///
+  /// Focus field if [shoudlFocus] is `true`.
+  /// By default `true`
+  ///
+  /// Auto scroll when focus invalid if [autoScrollWhenFocusOnInvalid] is `true`.
+  /// By default `false`.
+  void invalidate(
+    String errorText, {
+    bool shoudlFocus = true,
+    bool autoScrollWhenFocusOnInvalid = false,
+  }) {
     setState(() => _customErrorText = errorText);
-    validate(clearCustomError: false);
-    requestFocus();
+
+    validate(
+      clearCustomError: false,
+      autoScrollWhenFocusOnInvalid: autoScrollWhenFocusOnInvalid,
+      focusOnInvalid: shoudlFocus,
+    );
+  }
+
+  void focus() {
+    FocusScope.of(context).requestFocus(effectiveFocusNode);
+  }
+
+  void ensureScrollableVisibility() {
+    Scrollable.ensureVisible(context);
   }
 
   InputDecoration get decoration => widget.decoration.copyWith(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.0"
   fake_async:
     dependency: transitive
     description:
@@ -79,10 +79,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.6.5"
   lints:
     dependency: transitive
     description:
@@ -95,10 +95,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.14"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
@@ -111,18 +111,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "12307e7f0605ce3da64cf0db90e5fcab0869f3ca03f76be6bb2991ce0a55e82b"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -172,10 +172,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "6182294da5abf431177fccc1ee02401f6df30f766bc6130a0852c6b6d7ee6b2d"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.18"
+    version: "0.4.16"
   vector_math:
     dependency: transitive
     description:

--- a/test/form_builder_choice_chips_test.dart
+++ b/test/form_builder_choice_chips_test.dart
@@ -11,7 +11,6 @@ void main() {
       const widgetName = 'cc1';
 
       final testWidget = FormBuilderChoiceChip<int>(
-        shouldRequestFocus: false,
         name: widgetName,
         options: const [
           FormBuilderChipOption(key: ValueKey('1'), value: 1),
@@ -38,7 +37,6 @@ void main() {
       const widgetName = 'cc2';
 
       final testWidget = FormBuilderChoiceChip<int>(
-        shouldRequestFocus: false,
         name: widgetName,
         options: const [
           FormBuilderChipOption(key: ValueKey('1'), value: 1),
@@ -64,7 +62,6 @@ void main() {
       const widgetName = 'cc3';
 
       final testWidget = FormBuilderChoiceChip<int>(
-        shouldRequestFocus: false,
         name: widgetName,
         initialValue: 1,
         options: const [

--- a/test/form_builder_filter_chips_test.dart
+++ b/test/form_builder_filter_chips_test.dart
@@ -10,7 +10,6 @@ void main() {
       const widgetName = 'formBuilderFilterChip';
 
       final testWidget = FormBuilderFilterChip<int>(
-        shouldRequestFocus: false,
         name: widgetName,
         options: const [
           FormBuilderChipOption(key: ValueKey('1'), value: 1),
@@ -36,7 +35,6 @@ void main() {
         const widgetName = 'fc2';
 
         final testWidget = FormBuilderFilterChip<int>(
-          shouldRequestFocus: false,
           name: widgetName,
           options: const [
             FormBuilderChipOption(key: ValueKey('1'), value: 1),
@@ -68,7 +66,6 @@ void main() {
         const widgetName = 'fc3';
 
         final testWidget = FormBuilderFilterChip<int>(
-          shouldRequestFocus: false,
           name: widgetName,
           initialValue: const [1],
           options: const [

--- a/test/form_builder_radio_group_test.dart
+++ b/test/form_builder_radio_group_test.dart
@@ -7,7 +7,6 @@ void main() {
   testWidgets('FormBuilderRadioGroup -- 1,3', (WidgetTester tester) async {
     const widgetName = 'rg1';
     final testWidget = FormBuilderRadioGroup<int>(
-      shouldRadioRequestFocus: false,
       name: widgetName,
       options: const [
         FormBuilderFieldOption(key: ValueKey('1'), value: 1),

--- a/test/src/form_builder_field_test.dart
+++ b/test/src/form_builder_field_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import '../form_builder_tester.dart';
 
 void main() {
-  group('Form Builder Field -', () {
+  group('FormBuilderField -', () {
     testWidgets('Reset custom error from form builder', (tester) async {
       const textFieldName = 'text1';
       const errorTextField = 'error text field';
@@ -13,8 +13,7 @@ void main() {
       await tester.pumpWidget(buildTestableFieldWidget(testWidget));
 
       // Set custom error
-      formKey.currentState
-          ?.invalidateField(name: textFieldName, errorText: errorTextField);
+      formKey.currentState?.fields[textFieldName]?.invalidate(errorTextField);
       await tester.pumpAndSettle();
       expect(find.text(errorTextField), findsOneWidget);
 


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #955
Close #1049

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->
Connected to https://github.com/flutter-form-builder-ecosystem/form_builder_extra_fields/issues/10

## Solution description

BREAKING CHANGE

This PR improve how handle and use focus and scroll when validate and invalidate fields.
Now, we have two news behaviors when validate or invalidate a field or form:
- By default, the first or single field with validation error, will be focused
- Only if `autoScrollWhenFocusOnInvalid` will be true, automatic scroll will happens and will show the first or single error. By default, this behavior is deactivate

Note: If a invalid field is from type **TextField** and will focused, the form will auto scroll to show this invalid field. 
In this case, the automatic scroll happens because is a behavior inside the framework, not because `autoScrollWhenFocusOnInvalid` is true.

- Remove property `shouldRequestFocus` for each form field
- Remove property `autoFocusOnValidationFailure` on FormBuilder
- Add `focusOnInvalid` and `autoScrollWhenFocusOnInvalid` to `validate` and `saveAndValidate` methods from `FormBuilderState`
- Add `focusOnInvalid` and `autoScrollWhenFocusOnInvalid` to `validate` method from `FormBuilderFieldState`
- Add `shouldFocus` and `shouldAutoScrollWhenFocus` to `invalidate` method from `FormBuilderFieldState`

In other hand, remove and add some deprecated fields and update example config.

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
