### PR TITLE
Apply validation on init when autovalidate is always

### DIFF
--- a/test/flutter_form_builder_test.dart
+++ b/test/flutter_form_builder_test.dart
@@ -177,6 +177,20 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text(errorTextField), findsOneWidget);
   });
+  testWidgets('Should show error when init form and AutovalidateMode is always',
+      (tester) async {
+    const textFieldName = 'text4';
+    const errorTextField = 'error text field';
+    final testWidget = FormBuilderTextField(
+      name: textFieldName,
+      validator: (value) => errorTextField,
+      autovalidateMode: AutovalidateMode.always,
+    );
+    await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+    await tester.pumpAndSettle();
+
+    expect(find.text(errorTextField), findsOneWidget);
+  });
 }
 
 // simple stateful widget that can hide and show its child with the intent of

--- a/test/form_builder_tester.dart
+++ b/test/form_builder_tester.dart
@@ -8,6 +8,7 @@ Widget buildTestableFieldWidget(
   Map<String, dynamic> initialValue = const {},
   bool skipDisabled = false,
   bool clearValueOnUnregister = false,
+  AutovalidateMode? autovalidateMode,
 }) {
   return MaterialApp(
     home: Scaffold(
@@ -16,6 +17,7 @@ Widget buildTestableFieldWidget(
         skipDisabled: skipDisabled,
         initialValue: initialValue,
         clearValueOnUnregister: clearValueOnUnregister,
+        autovalidateMode: autovalidateMode,
         child: widget,
       ),
     ),

--- a/test/src/form_builder_field_test.dart
+++ b/test/src/form_builder_field_test.dart
@@ -42,5 +42,24 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.text(errorTextField), findsNothing);
     });
+    testWidgets(
+        'Should show error when init form and AutovalidateMode is always',
+        (tester) async {
+      const textFieldName = 'text4';
+      const errorTextField = 'error text field';
+      final testWidget = FormBuilderTextField(
+        name: textFieldName,
+        validator: (value) => errorTextField,
+      );
+      await tester.pumpWidget(
+        buildTestableFieldWidget(
+          testWidget,
+          autovalidateMode: AutovalidateMode.always,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(errorTextField), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #1188 

## Solution description

On init field form, verify if autovalidate mode is always and validate field

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme
