### PR TITLE
Improve autovalidate modes

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.6.10'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -14,15 +14,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/lib/src/extensions/autovalidatemode_extension.dart
+++ b/lib/src/extensions/autovalidatemode_extension.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+extension AutovalidateModeExtension on AutovalidateMode {
+  /// Is always or is onUserInteraction
+  bool get isEnable => isAlways || isOnUserInteraction;
+  bool get isAlways => this == AutovalidateMode.always;
+  bool get isOnUserInteraction => this == AutovalidateMode.onUserInteraction;
+}

--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/src/extensions/autovalidatemode_extension.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 /// A container for form fields.
@@ -151,23 +152,16 @@ class FormBuilderState extends State<FormBuilder> {
         initialValue[name];
   }
 
-  void setInternalFieldValue<T>(String name, T? value,
-      {required bool isSetState}) {
+  void setInternalFieldValue<T>(String name, T? value) {
     _instantValue[name] = value;
-    if (isSetState) {
-      setState(() {});
+    if (widget.autovalidateMode?.isEnable ?? false) {
+      validate();
     }
     widget.onChanged?.call();
   }
 
-  void removeInternalFieldValue(
-    String name, {
-    required bool isSetState,
-  }) {
+  void removeInternalFieldValue(String name) {
     _instantValue.remove(name);
-    if (isSetState) {
-      setState(() {});
-    }
   }
 
   void registerField(String name, FormBuilderFieldState field) {

--- a/test/src/form_builder_field_test.dart
+++ b/test/src/form_builder_field_test.dart
@@ -24,6 +24,58 @@ void main() {
         expect(find.text(errorTextField), findsOneWidget);
       });
     });
+    group('isValid -', () {
+      testWidgets('Should invalid when set custom error', (tester) async {
+        final textFieldKey = GlobalKey<FormBuilderFieldState>();
+        const textFieldName = 'text';
+        const errorTextField = 'error text field';
+        final testWidget = FormBuilderTextField(
+          name: textFieldName,
+          key: textFieldKey,
+        );
+        await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+        // Set custom error
+        textFieldKey.currentState?.invalidate(errorTextField);
+        await tester.pumpAndSettle();
+
+        expect(textFieldKey.currentState?.isValid, isFalse);
+      });
+    });
+    group('hasErrors -', () {
+      testWidgets('Should has errors when set custom error', (tester) async {
+        final textFieldKey = GlobalKey<FormBuilderFieldState>();
+        const textFieldName = 'text';
+        const errorTextField = 'error text field';
+        final testWidget = FormBuilderTextField(
+          name: textFieldName,
+          key: textFieldKey,
+        );
+        await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+        // Set custom error
+        textFieldKey.currentState?.invalidate(errorTextField);
+        await tester.pumpAndSettle();
+
+        expect(textFieldKey.currentState?.hasError, isTrue);
+      });
+      testWidgets('Should no has errors when is empty and no has validators',
+          (tester) async {
+        final textFieldKey = GlobalKey<FormBuilderFieldState>();
+        const textFieldName = 'text';
+        final testWidget = FormBuilderTextField(
+          name: textFieldName,
+          key: textFieldKey,
+        );
+        await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+        // Set custom error
+        textFieldKey.currentState?.validate();
+        await tester.pumpAndSettle();
+
+        expect(textFieldKey.currentState?.hasError, isFalse);
+      });
+    });
 
     group('autovalidateMode -', () {
       testWidgets(
@@ -33,14 +85,29 @@ void main() {
         const errorTextField = 'error text field';
         final testWidget = FormBuilderTextField(
           name: textFieldName,
+          validator: (value) =>
+              value == null || value.isEmpty ? errorTextField : null,
+          autovalidateMode: AutovalidateMode.always,
+        );
+        await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+        await tester.pumpAndSettle();
+
+        expect(find.text(errorTextField), findsOneWidget);
+      });
+      testWidgets(
+          'Should show error when AutovalidateMode is onUserInteraction and change field',
+          (tester) async {
+        const textFieldName = 'text4';
+        const errorTextField = 'error text field';
+        final testWidget = FormBuilderTextField(
+          name: textFieldName,
+          autovalidateMode: AutovalidateMode.onUserInteraction,
           validator: (value) => errorTextField,
         );
-        await tester.pumpWidget(
-          buildTestableFieldWidget(
-            testWidget,
-            autovalidateMode: AutovalidateMode.always,
-          ),
-        );
+        await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+        expect(find.text(errorTextField), findsNothing);
+
+        await tester.enterText(find.byWidget(testWidget), 'hola');
         await tester.pumpAndSettle();
 
         expect(find.text(errorTextField), findsOneWidget);

--- a/test/src/form_builder_field_test.dart
+++ b/test/src/form_builder_field_test.dart
@@ -24,6 +24,7 @@ void main() {
         expect(find.text(errorTextField), findsOneWidget);
       });
     });
+
     group('isValid -', () {
       testWidgets('Should invalid when set custom error', (tester) async {
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
@@ -41,7 +42,54 @@ void main() {
 
         expect(textFieldKey.currentState?.isValid, isFalse);
       });
+      testWidgets(
+          'Should valid when no has error and autovalidateMode is always',
+          (tester) async {
+        final textFieldKey = GlobalKey<FormBuilderFieldState>();
+        const textFieldName = 'text';
+        const errorTextField = 'error text field';
+        final testWidget = FormBuilderTextField(
+          name: textFieldName,
+          key: textFieldKey,
+          autovalidateMode: AutovalidateMode.always,
+          validator: (value) =>
+              value == null || value.isEmpty ? errorTextField : null,
+        );
+        await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+        expect(textFieldKey.currentState?.isValid, isFalse);
+
+        final widgetFinder = find.byWidget(testWidget);
+        await tester.enterText(widgetFinder, 'test');
+        await tester.pumpAndSettle();
+
+        expect(textFieldKey.currentState?.isValid, isTrue);
+      });
+      testWidgets(
+          'Should invalid when has error and autovalidateMode is always',
+          (tester) async {
+        final textFieldKey = GlobalKey<FormBuilderFieldState>();
+        const textFieldName = 'text';
+        const errorTextField = 'error text field';
+        final testWidget = FormBuilderTextField(
+          name: textFieldName,
+          key: textFieldKey,
+          autovalidateMode: AutovalidateMode.always,
+          validator: (value) =>
+              value == null || value.length < 10 ? errorTextField : null,
+        );
+        await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+        expect(textFieldKey.currentState?.isValid, isFalse);
+
+        final widgetFinder = find.byWidget(testWidget);
+        await tester.enterText(widgetFinder, 'test');
+        await tester.pumpAndSettle();
+
+        expect(textFieldKey.currentState?.isValid, isFalse);
+      });
     });
+
     group('hasErrors -', () {
       testWidgets('Should has errors when set custom error', (tester) async {
         final textFieldKey = GlobalKey<FormBuilderFieldState>();

--- a/test/src/form_builder_test.dart
+++ b/test/src/form_builder_test.dart
@@ -118,6 +118,65 @@ void main() {
     );
   });
 
+  group('isValid -', () {
+    testWidgets('Should invalid when set custom error', (tester) async {
+      const textFieldName = 'text';
+      const errorTextField = 'error text field';
+      final testWidget = FormBuilderTextField(name: textFieldName);
+      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+      // Set custom error
+      formKey.currentState?.fields[textFieldName]?.invalidate(errorTextField);
+      await tester.pumpAndSettle();
+
+      expect(formKey.currentState?.isValid, isFalse);
+    });
+    testWidgets('Should valid when no has error and autovalidateMode is always',
+        (tester) async {
+      const textFieldName = 'text';
+      const errorTextField = 'error text field';
+      final testWidget = FormBuilderTextField(
+        name: textFieldName,
+        validator: (value) =>
+            value == null || value.isEmpty ? errorTextField : null,
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(
+        testWidget,
+        autovalidateMode: AutovalidateMode.always,
+      ));
+
+      expect(formKey.currentState?.isValid, isFalse);
+
+      final widgetFinder = find.byWidget(testWidget);
+      await tester.enterText(widgetFinder, 'test');
+      await tester.pumpAndSettle();
+
+      expect(formKey.currentState?.isValid, isTrue);
+    });
+    testWidgets('Should invalid when has error and autovalidateMode is always',
+        (tester) async {
+      const textFieldName = 'text';
+      const errorTextField = 'error text field';
+      final testWidget = FormBuilderTextField(
+        name: textFieldName,
+        validator: (value) =>
+            value == null || value.length < 10 ? errorTextField : null,
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(
+        testWidget,
+        autovalidateMode: AutovalidateMode.always,
+      ));
+
+      expect(formKey.currentState?.isValid, isFalse);
+
+      final widgetFinder = find.byWidget(testWidget);
+      await tester.enterText(widgetFinder, 'test');
+      await tester.pumpAndSettle();
+
+      expect(formKey.currentState?.isValid, isFalse);
+    });
+  });
+
   group('skipDisabled -', () {
     testWidgets(
         'Should not show error when field is not enabled and skipDisabled is true',

--- a/test/src/form_builder_test.dart
+++ b/test/src/form_builder_test.dart
@@ -177,9 +177,11 @@ void main() {
       final testWidget = FormBuilderTextField(
         name: textFieldName,
         validator: (value) => errorTextField,
-        autovalidateMode: AutovalidateMode.always,
       );
-      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+      await tester.pumpWidget(buildTestableFieldWidget(
+        testWidget,
+        autovalidateMode: AutovalidateMode.always,
+      ));
       await tester.pumpAndSettle();
 
       expect(find.text(errorTextField), findsOneWidget);


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #1157

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

Connected to https://github.com/flutter/flutter/issues/125766

## Solution description

Improve how use autovalidateMode property on internal Form and Field Form states.
I thinks that's solution isn't perfect because exist a bug on Flutter Framework that create conflict in some cases when use different autovalidateMode on Form and on Field Form. I reported about this issue [here](https://github.com/flutter/flutter/issues/125766)

## Screenshots or Videos

[Screencast from 30-04-23 19:30:00.webm](https://user-images.githubusercontent.com/21011641/235367492-8766787e-23d6-4abd-957e-14e17b6f3b06.webm)

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme
