### PR TITLE
Implement errors getter on form builder state

### DIFF
--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -123,6 +123,13 @@ class FormBuilderState extends State<FormBuilder> {
   /// Touched: The field is focused by user or by logic code.
   bool get isTouched => fields.values.any((field) => field.isTouched);
 
+  /// Get a map of errors
+  Map<String, String> get errors => {
+        for (var element
+            in fields.entries.where((element) => element.value.hasError))
+          element.key.toString(): element.value.errorText ?? ''
+      };
+
   /// Get initialValue.
   Map<String, dynamic> get initialValue => widget.initialValue;
 

--- a/test/src/form_builder_test.dart
+++ b/test/src/form_builder_test.dart
@@ -398,6 +398,67 @@ void main() {
       expect(find.text(errorTextField), findsNothing);
     });
   });
+
+  group('errors -', () {
+    testWidgets('Should get errors when more than one fields are invalid',
+        (tester) async {
+      const textFieldName = 'text';
+      const checkboxName = 'checkbox';
+      const textFieldError = 'error text';
+      const checkboxError = 'error checkbox';
+      final testTextField = FormBuilderTextField(
+        name: textFieldName,
+        validator: (value) => textFieldError,
+      );
+      final testCheckbox = FormBuilderCheckbox(
+        title: const Text('title'),
+        name: checkboxName,
+        validator: (value) => checkboxError,
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(
+        Column(children: [testTextField, testCheckbox]),
+        autovalidateMode: AutovalidateMode.always,
+      ));
+
+      expect(
+        formKey.currentState?.errors,
+        equals({
+          textFieldName: textFieldError,
+          checkboxName: checkboxError,
+        }),
+      );
+    });
+    testWidgets('Should get errors when one field are invalid', (tester) async {
+      const textFieldName = 'text';
+      const textFieldError = 'error text';
+      final testTextField = FormBuilderTextField(
+        name: textFieldName,
+        validator: (value) => textFieldError,
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(
+        testTextField,
+        autovalidateMode: AutovalidateMode.always,
+      ));
+
+      expect(
+        formKey.currentState?.errors,
+        equals({textFieldName: textFieldError}),
+      );
+    });
+    testWidgets('Should not get errors when all fields are valid',
+        (tester) async {
+      const textFieldName = 'text';
+      final testTextField = FormBuilderTextField(
+        name: textFieldName,
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(
+        testTextField,
+        autovalidateMode: AutovalidateMode.always,
+      ));
+
+      expect(formKey.currentState?.errors, equals({}));
+    });
+  });
 }
 
 // simple stateful widget that can hide and show its child with the intent of


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #1014

## Solution description

- Filter fields with errors and convert to map with name and errorText

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
