### PR TITLE
Remove input decoration

### DIFF
--- a/example/lib/code_page.dart
+++ b/example/lib/code_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-// import 'package:widget_with_codeview/widget_with_codeview.dart';
 
 class CodePage extends StatelessWidget {
   final String title;

--- a/example/lib/sources/signup_form.dart
+++ b/example/lib/sources/signup_form.dart
@@ -66,7 +66,7 @@ class _SignupFormState extends State<SignupForm> {
                       : null,
             ),
             const SizedBox(height: 10),
-            FormBuilderField<bool>(
+            FormBuilderFieldDecoration<bool>(
               name: 'test',
               validator: FormBuilderValidators.compose([
                 FormBuilderValidators.required(),

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -1,8 +1,0 @@
-import 'package:flutter_test/flutter_test.dart';
-
-void main() {
-  testWidgets('FormBuilderTextField -- Hello Planet',
-      (WidgetTester tester) async {
-    expect(true, isTrue); // 😀
-  });
-}

--- a/lib/flutter_form_builder.dart
+++ b/lib/flutter_form_builder.dart
@@ -2,6 +2,7 @@ library flutter_form_builder;
 
 export 'src/form_builder.dart';
 export 'src/form_builder_field.dart';
+export 'src/form_builder_field_decoration.dart';
 export 'src/form_builder_field_option.dart';
 export 'src/fields/form_builder_checkbox.dart';
 export 'src/fields/form_builder_checkbox_group.dart';

--- a/lib/src/extensions/autovalidatemode_extension.dart
+++ b/lib/src/extensions/autovalidatemode_extension.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 extension AutovalidateModeExtension on AutovalidateMode {
   /// Is always or is onUserInteraction

--- a/lib/src/fields/form_builder_checkbox.dart
+++ b/lib/src/fields/form_builder_checkbox.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 /// Single Checkbox field
-class FormBuilderCheckbox extends FormBuilderField<bool> {
+class FormBuilderCheckbox extends FormBuilderFieldDecoration<bool> {
   /// The primary content of the CheckboxListTile.
   ///
   /// Typically a [Text] widget.
@@ -146,9 +146,9 @@ class FormBuilderCheckbox extends FormBuilderField<bool> {
         );
 
   @override
-  FormBuilderFieldState<FormBuilderCheckbox, bool> createState() =>
+  FormBuilderFieldDecorationState<FormBuilderCheckbox, bool> createState() =>
       _FormBuilderCheckboxState();
 }
 
 class _FormBuilderCheckboxState
-    extends FormBuilderFieldState<FormBuilderCheckbox, bool> {}
+    extends FormBuilderFieldDecorationState<FormBuilderCheckbox, bool> {}

--- a/lib/src/fields/form_builder_checkbox_group.dart
+++ b/lib/src/fields/form_builder_checkbox_group.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 /// A list of Checkboxes for selecting multiple options
-class FormBuilderCheckboxGroup<T> extends FormBuilderField<List<T>> {
+class FormBuilderCheckboxGroup<T> extends FormBuilderFieldDecoration<List<T>> {
   final List<FormBuilderFieldOption<T>> options;
   final Color? activeColor;
   final Color? checkColor;
@@ -96,9 +96,9 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderField<List<T>> {
         );
 
   @override
-  FormBuilderFieldState<FormBuilderCheckboxGroup<T>, List<T>> createState() =>
-      _FormBuilderCheckboxGroupState<T>();
+  FormBuilderFieldDecorationState<FormBuilderCheckboxGroup<T>, List<T>>
+      createState() => _FormBuilderCheckboxGroupState<T>();
 }
 
-class _FormBuilderCheckboxGroupState<T>
-    extends FormBuilderFieldState<FormBuilderCheckboxGroup<T>, List<T>> {}
+class _FormBuilderCheckboxGroupState<T> extends FormBuilderFieldDecorationState<
+    FormBuilderCheckboxGroup<T>, List<T>> {}

--- a/lib/src/fields/form_builder_choice_chips.dart
+++ b/lib/src/fields/form_builder_choice_chips.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 /// A list of `Chip`s that acts like radio buttons
-class FormBuilderChoiceChip<T> extends FormBuilderField<T> {
+class FormBuilderChoiceChip<T> extends FormBuilderFieldDecoration<T> {
   /// The list of items the user can select.
   final List<FormBuilderChipOption<T>> options;
 
@@ -337,9 +337,9 @@ class FormBuilderChoiceChip<T> extends FormBuilderField<T> {
         });
 
   @override
-  FormBuilderFieldState<FormBuilderChoiceChip<T>, T> createState() =>
+  FormBuilderFieldDecorationState<FormBuilderChoiceChip<T>, T> createState() =>
       _FormBuilderChoiceChipState<T>();
 }
 
 class _FormBuilderChoiceChipState<T>
-    extends FormBuilderFieldState<FormBuilderChoiceChip<T>, T> {}
+    extends FormBuilderFieldDecorationState<FormBuilderChoiceChip<T>, T> {}

--- a/lib/src/fields/form_builder_date_range_picker.dart
+++ b/lib/src/fields/form_builder_date_range_picker.dart
@@ -7,7 +7,8 @@ import 'package:intl/intl.dart' as intl;
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 /// Field for selecting a range of dates
-class FormBuilderDateRangePicker extends FormBuilderField<DateTimeRange> {
+class FormBuilderDateRangePicker
+    extends FormBuilderFieldDecoration<DateTimeRange> {
   //TODO: Add documentation
   final int maxLines;
   final TextInputType? keyboardType;
@@ -169,7 +170,7 @@ class FormBuilderDateRangePicker extends FormBuilderField<DateTimeRange> {
         );
 
   @override
-  FormBuilderFieldState<FormBuilderDateRangePicker, DateTimeRange>
+  FormBuilderFieldDecorationState<FormBuilderDateRangePicker, DateTimeRange>
       createState() => _FormBuilderDateRangePickerState();
 
   static String tryFormat(DateTime date, intl.DateFormat format) {
@@ -182,8 +183,8 @@ class FormBuilderDateRangePicker extends FormBuilderField<DateTimeRange> {
   }
 }
 
-class _FormBuilderDateRangePickerState
-    extends FormBuilderFieldState<FormBuilderDateRangePicker, DateTimeRange> {
+class _FormBuilderDateRangePickerState extends FormBuilderFieldDecorationState<
+    FormBuilderDateRangePicker, DateTimeRange> {
   late TextEditingController _effectiveController;
 
   @override

--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -10,7 +10,7 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 enum InputType { date, time, both }
 
 /// Field for `Date`, `Time` and `DateTime` input
-class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
+class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
   /// The date/time picker dialogs to show.
   final InputType inputType;
 
@@ -234,12 +234,12 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
         );
 
   @override
-  FormBuilderFieldState<FormBuilderDateTimePicker, DateTime> createState() =>
-      _FormBuilderDateTimePickerState();
+  FormBuilderFieldDecorationState<FormBuilderDateTimePicker, DateTime>
+      createState() => _FormBuilderDateTimePickerState();
 }
 
-class _FormBuilderDateTimePickerState
-    extends FormBuilderFieldState<FormBuilderDateTimePicker, DateTime> {
+class _FormBuilderDateTimePickerState extends FormBuilderFieldDecorationState<
+    FormBuilderDateTimePicker, DateTime> {
   late TextEditingController _textFieldController;
 
   late DateFormat _dateFormat;

--- a/lib/src/fields/form_builder_dropdown.dart
+++ b/lib/src/fields/form_builder_dropdown.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 /// Field for Dropdown button
-class FormBuilderDropdown<T> extends FormBuilderField<T> {
+class FormBuilderDropdown<T> extends FormBuilderFieldDecoration<T> {
   /// The list of items the user can select.
   ///
   /// If the [onChanged] callback is null or the list of items is null
@@ -300,9 +300,9 @@ class FormBuilderDropdown<T> extends FormBuilderField<T> {
         );
 
   @override
-  FormBuilderFieldState<FormBuilderDropdown<T>, T> createState() =>
+  FormBuilderFieldDecorationState<FormBuilderDropdown<T>, T> createState() =>
       _FormBuilderDropdownState<T>();
 }
 
 class _FormBuilderDropdownState<T>
-    extends FormBuilderFieldState<FormBuilderDropdown<T>, T> {}
+    extends FormBuilderFieldDecorationState<FormBuilderDropdown<T>, T> {}

--- a/lib/src/fields/form_builder_filter_chips.dart
+++ b/lib/src/fields/form_builder_filter_chips.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 /// Field with chips that acts like a list checkboxes.
-class FormBuilderFilterChip<T> extends FormBuilderField<List<T>> {
+class FormBuilderFilterChip<T> extends FormBuilderFieldDecoration<List<T>> {
   //TODO: Add documentation
   final Color? backgroundColor;
   final Color? disabledColor;
@@ -134,9 +134,9 @@ class FormBuilderFilterChip<T> extends FormBuilderField<List<T>> {
         );
 
   @override
-  FormBuilderFieldState<FormBuilderFilterChip<T>, List<T>> createState() =>
-      _FormBuilderFilterChipState<T>();
+  FormBuilderFieldDecorationState<FormBuilderFilterChip<T>, List<T>>
+      createState() => _FormBuilderFilterChipState<T>();
 }
 
-class _FormBuilderFilterChipState<T>
-    extends FormBuilderFieldState<FormBuilderFilterChip<T>, List<T>> {}
+class _FormBuilderFilterChipState<T> extends FormBuilderFieldDecorationState<
+    FormBuilderFilterChip<T>, List<T>> {}

--- a/lib/src/fields/form_builder_radio_group.dart
+++ b/lib/src/fields/form_builder_radio_group.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 /// Field to select one value from a list of Radio Widgets
-class FormBuilderRadioGroup<T> extends FormBuilderField<T> {
+class FormBuilderRadioGroup<T> extends FormBuilderFieldDecoration<T> {
   final Axis wrapDirection;
   final Color? activeColor;
   final Color? focusColor;
@@ -90,9 +90,9 @@ class FormBuilderRadioGroup<T> extends FormBuilderField<T> {
         );
 
   @override
-  FormBuilderFieldState<FormBuilderRadioGroup<T>, T> createState() =>
+  FormBuilderFieldDecorationState<FormBuilderRadioGroup<T>, T> createState() =>
       _FormBuilderRadioGroupState<T>();
 }
 
 class _FormBuilderRadioGroupState<T>
-    extends FormBuilderFieldState<FormBuilderRadioGroup<T>, T> {}
+    extends FormBuilderFieldDecorationState<FormBuilderRadioGroup<T>, T> {}

--- a/lib/src/fields/form_builder_range_slider.dart
+++ b/lib/src/fields/form_builder_range_slider.dart
@@ -3,7 +3,7 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:intl/intl.dart';
 
 /// Field to select a range of values on a Slider
-class FormBuilderRangeSlider extends FormBuilderField<RangeValues> {
+class FormBuilderRangeSlider extends FormBuilderFieldDecoration<RangeValues> {
   /// Called when the user starts selecting new values for the slider.
   ///
   /// This callback shouldn't be used to update the slider [values] (use
@@ -247,9 +247,9 @@ class FormBuilderRangeSlider extends FormBuilderField<RangeValues> {
         });
 
   @override
-  FormBuilderFieldState<FormBuilderRangeSlider, RangeValues> createState() =>
-      _FormBuilderRangeSliderState();
+  FormBuilderFieldDecorationState<FormBuilderRangeSlider, RangeValues>
+      createState() => _FormBuilderRangeSliderState();
 }
 
-class _FormBuilderRangeSliderState
-    extends FormBuilderFieldState<FormBuilderRangeSlider, RangeValues> {}
+class _FormBuilderRangeSliderState extends FormBuilderFieldDecorationState<
+    FormBuilderRangeSlider, RangeValues> {}

--- a/lib/src/fields/form_builder_segmented_control.dart
+++ b/lib/src/fields/form_builder_segmented_control.dart
@@ -5,7 +5,7 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 /// Field for selection of a value from the `CupertinoSegmentedControl`
 class FormBuilderSegmentedControl<T extends Object>
-    extends FormBuilderField<T> {
+    extends FormBuilderFieldDecoration<T> {
   /// The color used to fill the backgrounds of unselected widgets and as the
   /// text color of the selected widget.
   ///
@@ -101,9 +101,10 @@ class FormBuilderSegmentedControl<T extends Object>
         );
 
   @override
-  FormBuilderFieldState<FormBuilderSegmentedControl<T>, T> createState() =>
-      _FormBuilderSegmentedControlState();
+  FormBuilderFieldDecorationState<FormBuilderSegmentedControl<T>, T>
+      createState() => _FormBuilderSegmentedControlState();
 }
 
 class _FormBuilderSegmentedControlState<T extends Object>
-    extends FormBuilderFieldState<FormBuilderSegmentedControl<T>, T> {}
+    extends FormBuilderFieldDecorationState<FormBuilderSegmentedControl<T>,
+        T> {}

--- a/lib/src/fields/form_builder_slider.dart
+++ b/lib/src/fields/form_builder_slider.dart
@@ -1,16 +1,6 @@
 import 'package:flutter/material.dart';
-
 import 'package:intl/intl.dart';
-
 import 'package:flutter_form_builder/flutter_form_builder.dart';
-
-/// Configuration to what values show on sliders
-///
-/// - `all`: Show all values
-/// - `current`: Show only the current value (middle)
-/// - `minMax`: Show only the min and max values (start and finish)
-/// - `none`: No show any values
-enum DisplayValues { all, current, minMax, none }
 
 /// Field for selection of a numerical value on a slider
 class FormBuilderSlider extends FormBuilderField<double> {

--- a/lib/src/fields/form_builder_slider.dart
+++ b/lib/src/fields/form_builder_slider.dart
@@ -3,7 +3,7 @@ import 'package:intl/intl.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 /// Field for selection of a numerical value on a slider
-class FormBuilderSlider extends FormBuilderField<double> {
+class FormBuilderSlider extends FormBuilderFieldDecoration<double> {
   /// Called when the user starts selecting a new value for the slider.
   ///
   /// This callback shouldn't be used to update the slider [value] (use
@@ -273,9 +273,9 @@ class FormBuilderSlider extends FormBuilderField<double> {
         );
 
   @override
-  FormBuilderFieldState<FormBuilderSlider, double> createState() =>
+  FormBuilderFieldDecorationState<FormBuilderSlider, double> createState() =>
       _FormBuilderSliderState();
 }
 
 class _FormBuilderSliderState
-    extends FormBuilderFieldState<FormBuilderSlider, double> {}
+    extends FormBuilderFieldDecorationState<FormBuilderSlider, double> {}

--- a/lib/src/fields/form_builder_switch.dart
+++ b/lib/src/fields/form_builder_switch.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 /// On/Off switch field
-class FormBuilderSwitch extends FormBuilderField<bool> {
+class FormBuilderSwitch extends FormBuilderFieldDecoration<bool> {
   /// The primary content of the list tile.
   ///
   /// Typically a [Text] widget.
@@ -150,9 +150,9 @@ class FormBuilderSwitch extends FormBuilderField<bool> {
         );
 
   @override
-  FormBuilderFieldState<FormBuilderSwitch, bool> createState() =>
+  FormBuilderFieldDecorationState<FormBuilderSwitch, bool> createState() =>
       _FormBuilderSwitchState();
 }
 
 class _FormBuilderSwitchState
-    extends FormBuilderFieldState<FormBuilderSwitch, bool> {}
+    extends FormBuilderFieldDecorationState<FormBuilderSwitch, bool> {}

--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -6,7 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 /// A Material Design text field input.
-class FormBuilderTextField extends FormBuilderField<String> {
+class FormBuilderTextField extends FormBuilderFieldDecoration<String> {
   /// Controls the text being edited.
   ///
   /// If null, this widget will create its own [TextEditingController].
@@ -271,13 +271,14 @@ class FormBuilderTextField extends FormBuilderField<String> {
   ///{@macro flutter.widgets.text_selection.TextMagnifierConfiguration.details}
   final TextMagnifierConfiguration? magnifierConfiguration;
 
+  /// By default `false`
+  final bool readOnly;
+
   /// Creates a Material Design text field input.
   FormBuilderTextField({
     super.key,
     required super.name,
     super.validator,
-    String? initialValue,
-    bool readOnly = false,
     super.decoration,
     super.onChanged,
     super.valueTransformer,
@@ -287,6 +288,8 @@ class FormBuilderTextField extends FormBuilderField<String> {
     super.onReset,
     super.focusNode,
     super.restorationId,
+    String? initialValue,
+    this.readOnly = false,
     this.maxLines = 1,
     this.obscureText = false,
     this.textCapitalization = TextCapitalization.none,
@@ -348,8 +351,6 @@ class FormBuilderTextField extends FormBuilderField<String> {
           initialValue: controller != null ? controller.text : initialValue,
           builder: (FormFieldState<String?> field) {
             final state = field as _FormBuilderTextFieldState;
-            /*final effectiveDecoration = (decoration ?? const InputDecoration())
-                .applyDefaults(Theme.of(field.context).inputDecorationTheme);*/
 
             return TextField(
               restorationId: restorationId,
@@ -414,12 +415,12 @@ class FormBuilderTextField extends FormBuilderField<String> {
   }
 
   @override
-  FormBuilderFieldState<FormBuilderTextField, String> createState() =>
+  FormBuilderFieldDecorationState<FormBuilderTextField, String> createState() =>
       _FormBuilderTextFieldState();
 }
 
 class _FormBuilderTextFieldState
-    extends FormBuilderFieldState<FormBuilderTextField, String> {
+    extends FormBuilderFieldDecorationState<FormBuilderTextField, String> {
   TextEditingController? get _effectiveController =>
       widget.controller ?? _controller;
 

--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_form_builder/src/extensions/autovalidatemode_extension.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -38,9 +38,6 @@ class FormBuilderField<T> extends FormField<T> {
   /// Called when the field value is changed.
   final ValueChanged<T?>? onChanged;
 
-  // /// The border, labels, icons, and styles used to decorate the field.
-  // final InputDecoration decoration;
-
   /// Called when the field value is reset.
   final VoidCallback? onReset;
 
@@ -120,7 +117,7 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   bool get isValid => super.isValid && errorText == null;
 
   bool get enabled => widget.enabled && (_formBuilderState?.enabled ?? true);
-  bool get _readOnly => !(_formBuilderState?.widget.skipDisabled ?? false);
+  bool get readOnly => !(_formBuilderState?.widget.skipDisabled ?? false);
   bool get _isEnableValidate =>
       widget.autovalidateMode.isEnable ||
       (_formBuilderState?.widget.autovalidateMode?.isEnable ?? false);
@@ -137,13 +134,6 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   ///
   /// The field is focused by user or by logic code
   bool get isTouched => _touched;
-
-  // InputDecoration get decoration => widget.decoration.copyWith(
-  //       errorText: widget.enabled || _readOnly
-  //           ? widget.decoration.errorText ?? errorText
-  //           : null,
-  //       enabled: widget.enabled || _readOnly,
-  //     );
 
   void registerTransformer(Map<String, Function> map) {
     final fun = widget.valueTransformer;
@@ -166,7 +156,7 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
     focusAttachment = effectiveFocusNode.attach(context);
 
     // Verify if need auto validate form
-    if ((enabled || _readOnly) && _isAlwaysValidate) {
+    if ((enabled || readOnly) && _isAlwaysValidate) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         validate();
       });
@@ -203,7 +193,7 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   void _informFormForFieldChange() {
     if (_formBuilderState != null) {
       _dirty = true;
-      if (enabled || _readOnly) {
+      if (enabled || readOnly) {
         _formBuilderState!.setInternalFieldValue<T>(widget.name, value);
         if (_isEnableValidate) validate();
         return;
@@ -311,48 +301,4 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   void ensureScrollableVisibility() {
     Scrollable.ensureVisible(context);
   }
-}
-
-class FormBuilderFieldDecoration<T> extends FormBuilderField<T> {
-  const FormBuilderFieldDecoration({
-    super.key,
-    super.onSaved,
-    super.initialValue,
-    super.autovalidateMode,
-    super.enabled = true,
-    super.validator,
-    super.restorationId,
-    required super.name,
-    super.valueTransformer,
-    super.onChanged,
-    super.onReset,
-    super.focusNode,
-    required super.builder,
-    this.decoration = const InputDecoration(),
-  });
-  final InputDecoration decoration;
-
-  @override
-  FormBuilderFieldDecorationState<FormBuilderFieldDecoration<T>, T>
-      createState() =>
-          FormBuilderFieldDecorationState<FormBuilderFieldDecoration<T>, T>();
-}
-
-class FormBuilderFieldDecorationState<F extends FormBuilderFieldDecoration<T>,
-    T> extends FormBuilderFieldState<FormBuilderField<T>, T> {
-  @override
-  F get widget => super.widget as F;
-
-  InputDecoration get decoration => widget.decoration.copyWith(
-        errorText: widget.enabled || _readOnly
-            ? widget.decoration.errorText ?? errorText
-            : null,
-        enabled: widget.enabled || _readOnly,
-      );
-
-  @override
-  bool get hasError => super.hasError || widget.decoration.errorText != null;
-
-  @override
-  bool get isValid => super.isValid && widget.decoration.errorText == null;
 }

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -38,8 +38,8 @@ class FormBuilderField<T> extends FormField<T> {
   /// Called when the field value is changed.
   final ValueChanged<T?>? onChanged;
 
-  /// The border, labels, icons, and styles used to decorate the field.
-  final InputDecoration decoration;
+  // /// The border, labels, icons, and styles used to decorate the field.
+  // final InputDecoration decoration;
 
   /// Called when the field value is reset.
   final VoidCallback? onReset;
@@ -60,10 +60,26 @@ class FormBuilderField<T> extends FormField<T> {
     required this.name,
     this.valueTransformer,
     this.onChanged,
-    this.decoration = const InputDecoration(),
     this.onReset,
     this.focusNode,
   });
+
+  const factory FormBuilderField.decoration({
+    Key? key,
+    void Function(T?)? onSaved,
+    T? initialValue,
+    AutovalidateMode? autovalidateMode,
+    bool enabled,
+    String? Function(T?)? validator,
+    String? restorationId,
+    required Widget Function(FormFieldState<T>) builder,
+    required String name,
+    ValueTransformer<T?>? valueTransformer,
+    ValueChanged<T?>? onChanged,
+    VoidCallback? onReset,
+    FocusNode? focusNode,
+    InputDecoration decoration,
+  }) = FormBuilderFieldDecoration;
 
   @override
   FormBuilderFieldState<FormBuilderField<T>, T> createState() =>
@@ -98,12 +114,10 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   String? get errorText => super.errorText ?? _customErrorText;
 
   @override
-  bool get hasError =>
-      super.hasError || decoration.errorText != null || errorText != null;
+  bool get hasError => super.hasError || errorText != null;
 
   @override
-  bool get isValid =>
-      super.isValid && decoration.errorText == null && errorText == null;
+  bool get isValid => super.isValid && errorText == null;
 
   bool get enabled => widget.enabled && (_formBuilderState?.enabled ?? true);
   bool get _readOnly => !(_formBuilderState?.widget.skipDisabled ?? false);
@@ -124,12 +138,12 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   /// The field is focused by user or by logic code
   bool get isTouched => _touched;
 
-  InputDecoration get decoration => widget.decoration.copyWith(
-        errorText: widget.enabled || _readOnly
-            ? widget.decoration.errorText ?? errorText
-            : null,
-        enabled: widget.enabled || _readOnly,
-      );
+  // InputDecoration get decoration => widget.decoration.copyWith(
+  //       errorText: widget.enabled || _readOnly
+  //           ? widget.decoration.errorText ?? errorText
+  //           : null,
+  //       enabled: widget.enabled || _readOnly,
+  //     );
 
   void registerTransformer(Map<String, Function> map) {
     final fun = widget.valueTransformer;
@@ -297,4 +311,48 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   void ensureScrollableVisibility() {
     Scrollable.ensureVisible(context);
   }
+}
+
+class FormBuilderFieldDecoration<T> extends FormBuilderField<T> {
+  const FormBuilderFieldDecoration({
+    super.key,
+    super.onSaved,
+    super.initialValue,
+    super.autovalidateMode,
+    super.enabled = true,
+    super.validator,
+    super.restorationId,
+    required super.name,
+    super.valueTransformer,
+    super.onChanged,
+    super.onReset,
+    super.focusNode,
+    required super.builder,
+    this.decoration = const InputDecoration(),
+  });
+  final InputDecoration decoration;
+
+  @override
+  FormBuilderFieldDecorationState<FormBuilderFieldDecoration<T>, T>
+      createState() =>
+          FormBuilderFieldDecorationState<FormBuilderFieldDecoration<T>, T>();
+}
+
+class FormBuilderFieldDecorationState<F extends FormBuilderFieldDecoration<T>,
+    T> extends FormBuilderFieldState<FormBuilderField<T>, T> {
+  @override
+  F get widget => super.widget as F;
+
+  InputDecoration get decoration => widget.decoration.copyWith(
+        errorText: widget.enabled || _readOnly
+            ? widget.decoration.errorText ?? errorText
+            : null,
+        enabled: widget.enabled || _readOnly,
+      );
+
+  @override
+  bool get hasError => super.hasError || widget.decoration.errorText != null;
+
+  @override
+  bool get isValid => super.isValid && widget.decoration.errorText == null;
 }

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_form_builder/src/extensions/autovalidatemode_extension.dart';
 
@@ -60,23 +60,6 @@ class FormBuilderField<T> extends FormField<T> {
     this.onReset,
     this.focusNode,
   });
-
-  const factory FormBuilderField.decoration({
-    Key? key,
-    void Function(T?)? onSaved,
-    T? initialValue,
-    AutovalidateMode? autovalidateMode,
-    bool enabled,
-    String? Function(T?)? validator,
-    String? restorationId,
-    required Widget Function(FormFieldState<T>) builder,
-    required String name,
-    ValueTransformer<T?>? valueTransformer,
-    ValueChanged<T?>? onChanged,
-    VoidCallback? onReset,
-    FocusNode? focusNode,
-    InputDecoration decoration,
-  }) = FormBuilderFieldDecoration;
 
   @override
   FormBuilderFieldState<FormBuilderField<T>, T> createState() =>

--- a/lib/src/form_builder_field_decoration.dart
+++ b/lib/src/form_builder_field_decoration.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+
+class FormBuilderFieldDecoration<T> extends FormBuilderField<T> {
+  const FormBuilderFieldDecoration({
+    super.key,
+    super.onSaved,
+    super.initialValue,
+    super.autovalidateMode,
+    super.enabled = true,
+    super.validator,
+    super.restorationId,
+    required super.name,
+    super.valueTransformer,
+    super.onChanged,
+    super.onReset,
+    super.focusNode,
+    required super.builder,
+    this.decoration = const InputDecoration(),
+  });
+  final InputDecoration decoration;
+
+  @override
+  FormBuilderFieldDecorationState<FormBuilderFieldDecoration<T>, T>
+      createState() =>
+          FormBuilderFieldDecorationState<FormBuilderFieldDecoration<T>, T>();
+}
+
+class FormBuilderFieldDecorationState<F extends FormBuilderFieldDecoration<T>,
+    T> extends FormBuilderFieldState<FormBuilderField<T>, T> {
+  @override
+  F get widget => super.widget as F;
+
+  InputDecoration get decoration => widget.decoration.copyWith(
+        errorText: widget.enabled || readOnly
+            ? widget.decoration.errorText ?? errorText
+            : null,
+        enabled: widget.enabled || readOnly,
+      );
+
+  @override
+  bool get hasError => super.hasError || widget.decoration.errorText != null;
+
+  @override
+  bool get isValid => super.isValid && widget.decoration.errorText == null;
+}

--- a/lib/src/form_builder_field_option.dart
+++ b/lib/src/form_builder_field_option.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 /// An option for fields with selection options.
 ///

--- a/lib/src/form_builder_input_decoration.dart
+++ b/lib/src/form_builder_input_decoration.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+mixin FormBuilderInputDecoration {
+  final InputDecoration decoration = const InputDecoration();
+
+  InputDecoration get getdecoration => decoration.copyWith();
+
+  bool get hasDecorationError => decoration.errorText != null;
+}

--- a/lib/src/form_builder_input_decoration.dart
+++ b/lib/src/form_builder_input_decoration.dart
@@ -1,9 +1,0 @@
-import 'package:flutter/material.dart';
-
-mixin FormBuilderInputDecoration {
-  final InputDecoration decoration = const InputDecoration();
-
-  InputDecoration get getdecoration => decoration.copyWith();
-
-  bool get hasDecorationError => decoration.errorText != null;
-}

--- a/lib/src/options/form_builder_chip_option.dart
+++ b/lib/src/options/form_builder_chip_option.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 /// An option for filter chips.


### PR DESCRIPTION
## Solution description

BREAKING CHANGE

Add widget to remove decoration property from core. Now exist two field widgets:

1. FormBuilderField: **Refactored**. Now don't included decoration property or references to this property
2. FormBuilderFieldDecoration: **New**. Like the old `FormBuilderField`

The main goal for this change is made more _pure_ the `FormBuilderField`. Now in this widget (and others) only need import `package:flutter/widgets.dart` and no anymore the _material_ package.
This is useful to create field inputs to others platforms or with other styles, like [cupertino](https://github.com/flutter-form-builder-ecosystem/form_builder_cupertino_fields).

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [ ] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme
