### PR TITLE
Fix invalidate parameter word error

### DIFF
--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -253,7 +253,7 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
 
   /// Invalidate field with a [errorText]
   ///
-  /// Focus field if [shoudlFocus] is `true`.
+  /// Focus field if [shouldFocus] is `true`.
   /// By default `true`
   ///
   /// Auto scroll when focus invalid if [shouldAutoScrollWhenFocus] is `true`.
@@ -265,7 +265,7 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   /// not because [shouldAutoScrollWhenFocus] is `true`.
   void invalidate(
     String errorText, {
-    bool shoudlFocus = true,
+    bool shouldFocus = true,
     bool shouldAutoScrollWhenFocus = false,
   }) {
     setState(() => _customErrorText = errorText);
@@ -273,7 +273,7 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
     validate(
       clearCustomError: false,
       autoScrollWhenFocusOnInvalid: shouldAutoScrollWhenFocus,
-      focusOnInvalid: shoudlFocus,
+      focusOnInvalid: shouldFocus,
     );
   }
 


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #1250 

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Solution description
Fix invalidate parameter word error: `shoudlFocus -> shouldFocus`
## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [ ] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme
