### PR TITLE
fix: improve focus fields on validation

### DIFF
--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_form_builder/src/extensions/autovalidatemode_extension.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 /// A container for form fields.
@@ -107,6 +106,12 @@ class FormBuilderState extends State<FormBuilder> {
   final Map<String, dynamic> _savedValue = {};
   // Because dart type system will not accept ValueTransformer<dynamic>
   final Map<String, Function> _transformers = {};
+  bool _focusOnInvalid = true;
+
+  /// Will be true if will focus on invalid field when validate
+  ///
+  /// Only used to internal logic
+  bool get focusOnInvalid => _focusOnInvalid;
 
   bool get enabled => widget.enabled;
 
@@ -161,9 +166,6 @@ class FormBuilderState extends State<FormBuilder> {
 
   void setInternalFieldValue<T>(String name, T? value) {
     _instantValue[name] = value;
-    if (widget.autovalidateMode?.isEnable ?? false) {
-      validate();
-    }
     widget.onChanged?.call();
   }
 
@@ -253,6 +255,7 @@ class FormBuilderState extends State<FormBuilder> {
     bool focusOnInvalid = true,
     bool autoScrollWhenFocusOnInvalid = false,
   }) {
+    _focusOnInvalid = focusOnInvalid;
     final hasError = !_formKey.currentState!.validate();
     if (hasError) {
       final wrongFields =

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -101,9 +101,6 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
 
   bool get enabled => widget.enabled && (_formBuilderState?.enabled ?? true);
   bool get readOnly => !(_formBuilderState?.widget.skipDisabled ?? false);
-  bool get _isEnableValidate =>
-      widget.autovalidateMode.isEnable ||
-      (_formBuilderState?.widget.autovalidateMode?.isEnable ?? false);
   bool get _isAlwaysValidate =>
       widget.autovalidateMode.isAlways ||
       (_formBuilderState?.widget.autovalidateMode?.isAlways ?? false);
@@ -178,7 +175,6 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
       _dirty = true;
       if (enabled || readOnly) {
         _formBuilderState!.setInternalFieldValue<T>(widget.name, value);
-        if (_isEnableValidate) validate();
         return;
       }
       _formBuilderState!.removeInternalFieldValue(widget.name);
@@ -243,7 +239,14 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
     }
     final isValid = super.validate() && !hasError;
 
-    if (!isValid && focusOnInvalid && enabled) {
+    final fields = _formBuilderState?.fields ??
+        <String, FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>>{};
+
+    if (!isValid &&
+        focusOnInvalid &&
+        (formState?.focusOnInvalid ?? true) &&
+        enabled &&
+        !fields.values.any((e) => e.effectiveFocusNode.hasFocus)) {
       focus();
       if (autoScrollWhenFocusOnInvalid) ensureScrollableVisibility();
     }


### PR DESCRIPTION
## Connection with issue(s)

Close #1230

## Solution description

- Remove force validation on autovalidation enables modes
- Only focus on invalid field when no focus in another field
- Only focus on invalid field when `focusOnInvalid` is true

## Screenshots or Videos


https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/assets/21011641/710d9096-a6cd-418b-adec-a4bdc8b9f984

https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/assets/21011641/885836ec-cd99-4332-b73a-deb1e30a9031


## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
