### PR TITLE
fix: improve disabled decoration field form

### DIFF
--- a/lib/src/form_builder_field_decoration.dart
+++ b/lib/src/form_builder_field_decoration.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
+/// Extends [FormBuilderField] and add a `decoration` (InputDecoration) property
+///
+/// This class override `decoration.enable` with [enable] value
 class FormBuilderFieldDecoration<T> extends FormBuilderField<T> {
   const FormBuilderFieldDecoration({
     super.key,
@@ -36,7 +39,7 @@ class FormBuilderFieldDecorationState<F extends FormBuilderFieldDecoration<T>,
         errorText: widget.enabled || readOnly
             ? widget.decoration.errorText ?? errorText
             : null,
-        enabled: widget.enabled || readOnly,
+        enabled: widget.enabled,
       );
 
   @override


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #1259 

## Solution description

- Remove readonly property to enable decoration fields

## Screenshots or Videos

![Screenshot 2023-05-24 at 09 24 26](https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/assets/21011641/dd89b112-9dad-4aa7-b7e8-d4a08add68f1)

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
