### PR TITLE
feat: add onTapOutside to FormBuilderTextField

### DIFF
--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -204,12 +204,12 @@ class FormBuilderTextField extends FormBuilderFieldDecoration<String> {
   final GestureTapCallback? onTap;
 
   /// {@template flutter.material.textfield.onTapOutside}
-  /// A callback to be invoked when a tap is detected outside of this TapRegion 
+  /// A callback to be invoked when a tap is detected outside of this TapRegion
   /// and any other region with the same groupId, if any.
-  /// 
-  /// The PointerDownEvent passed to the function is the event that caused the 
-  /// notification. If this region is part of a group (i.e. groupId is set), 
-  /// then it's possible that the event may be outside of this immediate region, 
+  ///
+  /// The PointerDownEvent passed to the function is the event that caused the
+  /// notification. If this region is part of a group (i.e. groupId is set),
+  /// then it's possible that the event may be outside of this immediate region,
   /// although it will be within the region of one of the group members.
   /// {@endtemplate}
   final TapRegionCallback? onTapOutside;

--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -203,6 +203,17 @@ class FormBuilderTextField extends FormBuilderFieldDecoration<String> {
   /// {@endtemplate}
   final GestureTapCallback? onTap;
 
+  /// {@template flutter.material.textfield.onTapOutside}
+  /// A callback to be invoked when a tap is detected outside of this TapRegion 
+  /// and any other region with the same groupId, if any.
+  /// 
+  /// The PointerDownEvent passed to the function is the event that caused the 
+  /// notification. If this region is part of a group (i.e. groupId is set), 
+  /// then it's possible that the event may be outside of this immediate region, 
+  /// although it will be within the region of one of the group members.
+  /// {@endtemplate}
+  final TapRegionCallback? onTapOutside;
+
   /// The cursor for a mouse pointer when it enters or is hovering over the
   /// widget.
   ///
@@ -322,6 +333,7 @@ class FormBuilderTextField extends FormBuilderFieldDecoration<String> {
     this.minLines,
     this.showCursor,
     this.onTap,
+    this.onTapOutside,
     this.enableSuggestions = false,
     this.textAlignVertical,
     this.dragStartBehavior = DragStartBehavior.start,
@@ -381,6 +393,7 @@ class FormBuilderTextField extends FormBuilderFieldDecoration<String> {
               expands: expands,
               maxLength: maxLength,
               onTap: onTap,
+              onTapOutside: onTapOutside,
               onEditingComplete: onEditingComplete,
               onSubmitted: onSubmitted,
               inputFormatters: inputFormatters,

--- a/test/form_builder_text_field_test.dart
+++ b/test/form_builder_text_field_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -43,6 +44,11 @@ void main() {
       initialValueOnForm: 'ok',
     ),
   );
+
+  testWidgets(
+    'FormBuilderTextField triggers onTapOutside',
+    (tester) => _testFormBuilderTextFieldOnTapOutsideCallback(tester),
+  );
 }
 
 Future<void> _testFormBuilderTextFieldWithInitialValue(
@@ -74,4 +80,21 @@ Future<void> _testFormBuilderTextFieldWithInitialValue(
   expect(formValue(textFieldName), newTextValue);
 
   expect(changedCount, 1);
+}
+
+Future<void> _testFormBuilderTextFieldOnTapOutsideCallback(
+    WidgetTester tester) async {
+  const textFieldName = 'Hello 🪐';
+  bool triggered = false;
+
+  var testWidget = FormBuilderTextField(
+    name: textFieldName,
+    onTapOutside: (event) => triggered = true,
+  );
+  await tester.pumpWidget(buildTestableFieldWidget(
+    testWidget,
+  ));
+  final textField = tester.firstWidget(find.byType(TextField)) as TextField;
+  textField.onTapOutside?.call(const PointerDownEvent());
+  expect(triggered, true);
 }


### PR DESCRIPTION
Let me know if there's anything else that needs to be done, or if the solution needs to be fixed in any way.

## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #1266

## Solution description

Simply create a new property `TapRegionCallback? onTapOutside`, add it to the constructor and then pass it down to the widget.

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme