### PR TITLE
fix: check mounted after async

### DIFF
--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -309,6 +309,7 @@ class _FormBuilderDateTimePickerState extends FormBuilderFieldDecorationState<
       default:
         throw 'Unexpected input type ${widget.inputType}';
     }
+    if (!mounted) return null;
     final finalValue = newValue ?? currentValue;
     didChange(finalValue);
     return finalValue;


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #1210


## Solution description

Check if the widget is still mounted after returning from async call.

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [X] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme
