### PR TITLE
feat: add mouseCursor option to range and time picker to match other …

### DIFF
--- a/lib/src/fields/form_builder_date_range_picker.dart
+++ b/lib/src/fields/form_builder_date_range_picker.dart
@@ -35,6 +35,7 @@ class FormBuilderDateRangePicker
   final EdgeInsets scrollPadding;
   final bool enableInteractiveSelection;
   final InputCounterWidgetBuilder? buildCounter;
+  final MouseCursor? mouseCursor;
   final bool expands;
   final int? minLines;
   final bool showCursor;
@@ -106,6 +107,7 @@ class FormBuilderDateRangePicker
     this.cursorColor,
     this.keyboardAppearance,
     this.buildCounter,
+    this.mouseCursor,
     this.expands = false,
     this.minLines,
     this.showCursor = false,
@@ -146,6 +148,7 @@ class FormBuilderDateRangePicker
               autocorrect: autocorrect,
               autofocus: autofocus,
               buildCounter: buildCounter,
+              mouseCursor: mouseCursor,
               cursorColor: cursorColor,
               cursorRadius: cursorRadius,
               cursorWidth: cursorWidth,

--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -99,6 +99,7 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
   final VoidCallback? onEditingComplete;
 
   final InputCounterWidgetBuilder? buildCounter;
+  final MouseCursor? mouseCursor;
 
   final Radius? cursorRadius;
   final Color? cursorColor;
@@ -178,6 +179,7 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
     this.textInputAction,
     this.onEditingComplete,
     this.buildCounter,
+    this.mouseCursor,
     this.cursorRadius,
     this.cursorColor,
     this.keyboardAppearance,
@@ -219,6 +221,7 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
               style: style,
               onEditingComplete: onEditingComplete,
               buildCounter: buildCounter,
+              mouseCursor: mouseCursor,
               cursorColor: cursorColor,
               cursorRadius: cursorRadius,
               cursorWidth: cursorWidth,

--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -298,10 +298,11 @@ class _FormBuilderDateTimePickerState extends FormBuilderFieldDecorationState<
         newValue = await _showDatePicker(context, currentValue);
         break;
       case InputType.time:
-        final newTime = await _showTimePicker(context, currentValue);
-        newValue = null != newTime ? convert(newTime) : null;
+        if (!context.mounted) return null;
+        newValue = convert(await _showTimePicker(context, currentValue));
         break;
       case InputType.both:
+        if (!context.mounted) return null;
         final date = await _showDatePicker(context, currentValue);
         if (date != null) {
           if (!mounted) break;


### PR DESCRIPTION
Added optional parameter of mouseCursor to the date/time fields
The default FormBuilderTextField already has this 

## Connection with issue(s)

NA

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [ ] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme
