### PR TITLE
FormBuilderRangeSlider: Correct internal values when min/max changes

### DIFF
--- a/lib/src/fields/form_builder_range_slider.dart
+++ b/lib/src/fields/form_builder_range_slider.dart
@@ -197,9 +197,9 @@ class FormBuilderRangeSlider extends FormBuilderFieldDecoration<RangeValues> {
               field.value!.end < min ||
               field.value!.end > max) {
             if (initialValue == null) {
-              state.setValue(RangeValues(min, min));
+              field.setValue(RangeValues(min, min));
             } else {
-              state.setValue(
+              field.setValue(
                 RangeValues(initialValue.start, initialValue.end),
               );
             }

--- a/lib/src/fields/form_builder_range_slider.dart
+++ b/lib/src/fields/form_builder_range_slider.dart
@@ -191,8 +191,18 @@ class FormBuilderRangeSlider extends FormBuilderFieldDecoration<RangeValues> {
   }) : super(builder: (FormFieldState<RangeValues?> field) {
           final state = field as _FormBuilderRangeSliderState;
           final effectiveNumberFormat = numberFormat ?? NumberFormat.compact();
-          if (initialValue == null) {
-            field.setValue(RangeValues(min, min));
+          if (field.value == null ||
+              field.value!.start < min ||
+              field.value!.start > max ||
+              field.value!.end < min ||
+              field.value!.end > max) {
+            if (initialValue == null) {
+              state.setValue(RangeValues(min, min));
+            } else {
+              state.setValue(
+                RangeValues(initialValue.start, initialValue.end),
+              );
+            }
           }
           return InputDecorator(
             decoration: state.decoration,

--- a/test/form_builder_date_range_picker_test.dart
+++ b/test/form_builder_date_range_picker_test.dart
@@ -33,7 +33,7 @@ void main() {
       await tester.pump();
 
       // Close date range picker dialog
-      await tester.tap(find.text('SAVE'));
+      await tester.tap(find.text('Save'));
       await tester.pump();
 
       expect(formSave(), isTrue);

--- a/test/form_builder_range_slider_test.dart
+++ b/test/form_builder_range_slider_test.dart
@@ -27,6 +27,7 @@ void main() {
           tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
       final Offset rightTarget = topLeft + (bottomRight - topLeft) * 0.5;
       await tester.tapAt(rightTarget);
+      await tester.pumpAndSettle();
 
       expect(formSave(), isTrue);
       expect(formValue<RangeValues>(widgetName), const RangeValues(10.0, 15.0));
@@ -54,9 +55,66 @@ void main() {
           tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
       final Offset leftTarget = topLeft + (bottomRight - topLeft) * 0.1;
       await tester.tapAt(leftTarget);
+      await tester.pumpAndSettle();
 
       expect(formSave(), isTrue);
       expect(formValue<RangeValues>(widgetName), const RangeValues(11.0, 18.0));
     });
+
+    testWidgets('Stateful Update', (WidgetTester tester) async {
+      const widgetName = 'formBuilderRangeSlider';
+      const testWidget = _FormBuilderRangeSliderStateTest(widgetName);
+      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+      expect(formSave(), isTrue);
+      expect(
+        formValue<RangeValues?>(widgetName),
+        equals(const RangeValues(-10.0, 10.0)),
+      );
+
+      await tester.tapAt(tester.getCenter(find.byType(TextButton)));
+      await tester.pumpAndSettle();
+
+      expect(formSave(), isTrue);
+      expect(
+        formValue<RangeValues?>(widgetName),
+        equals(const RangeValues(-9.0, 9.0)),
+      );
+    });
   });
+}
+
+class _FormBuilderRangeSliderStateTest extends StatefulWidget {
+  final String name;
+
+  const _FormBuilderRangeSliderStateTest(this.name);
+
+  @override
+  State<StatefulWidget> createState() =>
+      _FormBuilderRangeSliderStateTestState();
+}
+
+class _FormBuilderRangeSliderStateTestState
+    extends State<_FormBuilderRangeSliderStateTest> {
+  double range = 10;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: FormBuilderRangeSlider(
+            name: widget.name,
+            min: -range,
+            max: range,
+            initialValue: RangeValues(-range, range),
+          ),
+        ),
+        TextButton(
+          onPressed: () => setState(() => range -= 1),
+          child: const Text('Reduce Range'),
+        )
+      ],
+    );
+  }
 }


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #[1330](https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/issues/1330)
Close #[1305](https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/issues/1305)

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->
<!--Connected to #???-->

## Solution description
Implemented solution described in #[1330](https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/issues/1330). TLDR: performed check to make sure that the current range is reset if it is out of bounds due to a change in the min/max of the slider range. Corrected logic when no initial value was specified and corrected unit tests to fail when the regression is readded (tests were missing pump of the tester). Added unit test and corrected a failed test due to incorrect selector. 

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
