### PR TITLE
Reintroduce ability to validate form field's value independent of input's error text

### DIFF
--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -62,12 +62,10 @@ class FormBuilderField<T> extends FormField<T> {
   });
 
   @override
-  FormBuilderFieldState<FormBuilderField<T>, T> createState() =>
-      FormBuilderFieldState<FormBuilderField<T>, T>();
+  FormBuilderFieldState<FormBuilderField<T>, T> createState() => FormBuilderFieldState<FormBuilderField<T>, T>();
 }
 
-class FormBuilderFieldState<F extends FormBuilderField<T>, T>
-    extends FormFieldState<T> {
+class FormBuilderFieldState<F extends FormBuilderField<T>, T> extends FormFieldState<T> {
   String? _customErrorText;
   FormBuilderState? _formBuilderState;
   bool _touched = false;
@@ -83,21 +81,25 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   /// Returns the initial value, which may be declared at the field, or by the
   /// parent [FormBuilder.initialValue]. When declared at both levels, the field
   /// initialValue prevails.
-  T? get initialValue =>
-      widget.initialValue ??
-      (_formBuilderState?.initialValue ??
-          const <String, dynamic>{})[widget.name] as T?;
+  T? get initialValue => widget.initialValue ?? (_formBuilderState?.initialValue ?? const <String, dynamic>{})[widget.name] as T?;
 
   dynamic get transformedValue => widget.valueTransformer?.call(value) ?? value;
 
   @override
   String? get errorText => super.errorText ?? _customErrorText;
 
+  @override
+  bool get hasError => super.hasError || errorText != null;
+
+  @override
+  bool get isValid => super.isValid && errorText == null;
+
+  bool get isValueValid => super.isValid;
+  bool get valueHasError => super.hasError;
+
   bool get enabled => widget.enabled && (_formBuilderState?.enabled ?? true);
   bool get readOnly => !(_formBuilderState?.widget.skipDisabled ?? false);
-  bool get _isAlwaysValidate =>
-      widget.autovalidateMode.isAlways ||
-      (_formBuilderState?.widget.autovalidateMode?.isAlways ?? false);
+  bool get _isAlwaysValidate => widget.autovalidateMode.isAlways || (_formBuilderState?.widget.autovalidateMode?.isAlways ?? false);
 
   /// Will be true if the field is dirty
   ///
@@ -233,14 +235,9 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
     }
     final isValid = super.validate() && !hasError;
 
-    final fields = _formBuilderState?.fields ??
-        <String, FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>>{};
+    final fields = _formBuilderState?.fields ?? <String, FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>>{};
 
-    if (!isValid &&
-        focusOnInvalid &&
-        (formState?.focusOnInvalid ?? true) &&
-        enabled &&
-        !fields.values.any((e) => e.effectiveFocusNode.hasFocus)) {
+    if (!isValid && focusOnInvalid && (formState?.focusOnInvalid ?? true) && enabled && !fields.values.any((e) => e.effectiveFocusNode.hasFocus)) {
       focus();
       if (autoScrollWhenFocusOnInvalid) ensureScrollableVisibility();
     }

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -93,12 +93,6 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   @override
   String? get errorText => super.errorText ?? _customErrorText;
 
-  @override
-  bool get hasError => super.hasError || errorText != null;
-
-  @override
-  bool get isValid => super.isValid && errorText == null;
-
   bool get enabled => widget.enabled && (_formBuilderState?.enabled ?? true);
   bool get readOnly => !(_formBuilderState?.widget.skipDisabled ?? false);
   bool get _isAlwaysValidate =>

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -94,7 +94,7 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T> extends FormFieldS
   @override
   bool get isValid => super.isValid && errorText == null;
 
-  bool get isValueValid => super.isValid;
+  bool get valueIsValid => super.isValid;
   bool get valueHasError => super.hasError;
 
   bool get enabled => widget.enabled && (_formBuilderState?.enabled ?? true);

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -62,10 +62,12 @@ class FormBuilderField<T> extends FormField<T> {
   });
 
   @override
-  FormBuilderFieldState<FormBuilderField<T>, T> createState() => FormBuilderFieldState<FormBuilderField<T>, T>();
+  FormBuilderFieldState<FormBuilderField<T>, T> createState() =>
+      FormBuilderFieldState<FormBuilderField<T>, T>();
 }
 
-class FormBuilderFieldState<F extends FormBuilderField<T>, T> extends FormFieldState<T> {
+class FormBuilderFieldState<F extends FormBuilderField<T>, T>
+    extends FormFieldState<T> {
   String? _customErrorText;
   FormBuilderState? _formBuilderState;
   bool _touched = false;
@@ -81,7 +83,10 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T> extends FormFieldS
   /// Returns the initial value, which may be declared at the field, or by the
   /// parent [FormBuilder.initialValue]. When declared at both levels, the field
   /// initialValue prevails.
-  T? get initialValue => widget.initialValue ?? (_formBuilderState?.initialValue ?? const <String, dynamic>{})[widget.name] as T?;
+  T? get initialValue =>
+      widget.initialValue ??
+      (_formBuilderState?.initialValue ??
+          const <String, dynamic>{})[widget.name] as T?;
 
   dynamic get transformedValue => widget.valueTransformer?.call(value) ?? value;
 
@@ -99,7 +104,9 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T> extends FormFieldS
 
   bool get enabled => widget.enabled && (_formBuilderState?.enabled ?? true);
   bool get readOnly => !(_formBuilderState?.widget.skipDisabled ?? false);
-  bool get _isAlwaysValidate => widget.autovalidateMode.isAlways || (_formBuilderState?.widget.autovalidateMode?.isAlways ?? false);
+  bool get _isAlwaysValidate =>
+      widget.autovalidateMode.isAlways ||
+      (_formBuilderState?.widget.autovalidateMode?.isAlways ?? false);
 
   /// Will be true if the field is dirty
   ///
@@ -235,9 +242,14 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T> extends FormFieldS
     }
     final isValid = super.validate() && !hasError;
 
-    final fields = _formBuilderState?.fields ?? <String, FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>>{};
+    final fields = _formBuilderState?.fields ??
+        <String, FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>>{};
 
-    if (!isValid && focusOnInvalid && (formState?.focusOnInvalid ?? true) && enabled && !fields.values.any((e) => e.effectiveFocusNode.hasFocus)) {
+    if (!isValid &&
+        focusOnInvalid &&
+        (formState?.focusOnInvalid ?? true) &&
+        enabled &&
+        !fields.values.any((e) => e.effectiveFocusNode.hasFocus)) {
       focus();
       if (autoScrollWhenFocusOnInvalid) ensureScrollableVisibility();
     }

--- a/test/src/form_builder_field_test.dart
+++ b/test/src/form_builder_field_test.dart
@@ -7,7 +7,8 @@ import '../form_builder_tester.dart';
 void main() {
   group('FormBuilderField -', () {
     group('custom error -', () {
-      testWidgets('Should show custom error when invalidate field', (tester) async {
+      testWidgets('Should show custom error when invalidate field',
+          (tester) async {
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
         const textFieldName = 'text2';
         const errorTextField = 'error text field';
@@ -41,7 +42,9 @@ void main() {
 
         expect(textFieldKey.currentState?.isValid, isFalse);
       });
-      testWidgets('Should valid when no has error and autovalidateMode is always', (tester) async {
+      testWidgets(
+          'Should valid when no has error and autovalidateMode is always',
+          (tester) async {
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
         const textFieldName = 'text';
         const errorTextField = 'error text field';
@@ -49,7 +52,8 @@ void main() {
           name: textFieldName,
           key: textFieldKey,
           autovalidateMode: AutovalidateMode.always,
-          validator: (value) => value == null || value.isEmpty ? errorTextField : null,
+          validator: (value) =>
+              value == null || value.isEmpty ? errorTextField : null,
         );
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
 
@@ -61,7 +65,9 @@ void main() {
 
         expect(textFieldKey.currentState?.isValid, isTrue);
       });
-      testWidgets('Should invalid when has error and autovalidateMode is always', (tester) async {
+      testWidgets(
+          'Should invalid when has error and autovalidateMode is always',
+          (tester) async {
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
         const textFieldName = 'text';
         const errorTextField = 'error text field';
@@ -69,7 +75,8 @@ void main() {
           name: textFieldName,
           key: textFieldKey,
           autovalidateMode: AutovalidateMode.always,
-          validator: (value) => value == null || value.length < 10 ? errorTextField : null,
+          validator: (value) =>
+              value == null || value.length < 10 ? errorTextField : null,
         );
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
 
@@ -100,7 +107,8 @@ void main() {
 
         expect(textFieldKey.currentState?.hasError, isTrue);
       });
-      testWidgets('Should no has errors when is empty and no has validators', (tester) async {
+      testWidgets('Should no has errors when is empty and no has validators',
+          (tester) async {
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
         const textFieldName = 'text';
         final testWidget = FormBuilderTextField(
@@ -118,7 +126,9 @@ void main() {
     });
 
     group('valueIsValid -', () {
-      testWidgets('Should value is valid when validator passes, despite set custom error', (tester) async {
+      testWidgets(
+          'Should value is valid when validator passes, despite set custom error',
+          (tester) async {
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
         const textFieldName = 'text';
         const errorTextField = 'error text field';
@@ -137,7 +147,8 @@ void main() {
     });
 
     group('valueHasError -', () {
-      testWidgets('Should value is invalid when validator passes', (tester) async {
+      testWidgets('Should value is invalid when validator passes',
+          (tester) async {
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
         const textFieldName = 'text';
         const invalidValue = 'invalid';
@@ -155,12 +166,15 @@ void main() {
     });
 
     group('autovalidateMode -', () {
-      testWidgets('Should show error when init form and AutovalidateMode is always', (tester) async {
+      testWidgets(
+          'Should show error when init form and AutovalidateMode is always',
+          (tester) async {
         const textFieldName = 'text4';
         const errorTextField = 'error text field';
         final testWidget = FormBuilderTextField(
           name: textFieldName,
-          validator: (value) => value == null || value.isEmpty ? errorTextField : null,
+          validator: (value) =>
+              value == null || value.isEmpty ? errorTextField : null,
           autovalidateMode: AutovalidateMode.always,
         );
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
@@ -168,7 +182,9 @@ void main() {
 
         expect(find.text(errorTextField), findsOneWidget);
       });
-      testWidgets('Should show error when AutovalidateMode is onUserInteraction and change field', (tester) async {
+      testWidgets(
+          'Should show error when AutovalidateMode is onUserInteraction and change field',
+          (tester) async {
         const textFieldName = 'text4';
         const errorTextField = 'error text field';
         final testWidget = FormBuilderTextField(
@@ -190,15 +206,18 @@ void main() {
       testWidgets('Should not dirty by default', (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
-        final testWidget = FormBuilderTextField(name: textFieldName, key: textFieldKey);
+        final testWidget =
+            FormBuilderTextField(name: textFieldName, key: textFieldKey);
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
 
         expect(textFieldKey.currentState?.isDirty, false);
       });
-      testWidgets('Should dirty when update field value by user', (tester) async {
+      testWidgets('Should dirty when update field value by user',
+          (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
-        final testWidget = FormBuilderTextField(name: textFieldName, key: textFieldKey);
+        final testWidget =
+            FormBuilderTextField(name: textFieldName, key: textFieldKey);
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
 
         final widgetFinder = find.byWidget(testWidget);
@@ -206,10 +225,12 @@ void main() {
 
         expect(textFieldKey.currentState?.isDirty, true);
       });
-      testWidgets('Should dirty when update field value by method', (tester) async {
+      testWidgets('Should dirty when update field value by method',
+          (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
-        final testWidget = FormBuilderTextField(name: textFieldName, key: textFieldKey);
+        final testWidget =
+            FormBuilderTextField(name: textFieldName, key: textFieldKey);
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
 
         textFieldKey.currentState?.setValue('test');
@@ -217,7 +238,8 @@ void main() {
 
         expect(textFieldKey.currentState?.isDirty, true);
       });
-      testWidgets('Should dirty when update field with initial value by user', (tester) async {
+      testWidgets('Should dirty when update field with initial value by user',
+          (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
         final testWidget = FormBuilderTextField(
@@ -232,7 +254,8 @@ void main() {
 
         expect(textFieldKey.currentState?.isDirty, true);
       });
-      testWidgets('Should dirty when update field with initial value by method', (tester) async {
+      testWidgets('Should dirty when update field with initial value by method',
+          (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
         final testWidget = FormBuilderTextField(
@@ -250,7 +273,8 @@ void main() {
       testWidgets('Should not dirty when reset field value', (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
-        final testWidget = FormBuilderTextField(name: textFieldName, key: textFieldKey);
+        final testWidget =
+            FormBuilderTextField(name: textFieldName, key: textFieldKey);
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
 
         textFieldKey.currentState?.setValue('test');
@@ -259,7 +283,8 @@ void main() {
 
         expect(textFieldKey.currentState?.isDirty, false);
       });
-      testWidgets('Should not dirty when reset field with initial value', (tester) async {
+      testWidgets('Should not dirty when reset field with initial value',
+          (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
         final testWidget = FormBuilderTextField(
@@ -281,7 +306,8 @@ void main() {
       testWidgets('Should not touched by default', (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
-        final testWidget = FormBuilderTextField(name: textFieldName, key: textFieldKey);
+        final testWidget =
+            FormBuilderTextField(name: textFieldName, key: textFieldKey);
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
 
         expect(textFieldKey.currentState?.isTouched, false);
@@ -289,7 +315,8 @@ void main() {
       testWidgets('Should touched when focus input', (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
-        final testWidget = FormBuilderTextField(name: textFieldName, key: textFieldKey);
+        final testWidget =
+            FormBuilderTextField(name: textFieldName, key: textFieldKey);
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
 
         final widgetFinder = find.byWidget(testWidget);
@@ -303,7 +330,8 @@ void main() {
       testWidgets('Should reset to null when call reset', (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
-        final testWidget = FormBuilderTextField(name: textFieldName, key: textFieldKey);
+        final testWidget =
+            FormBuilderTextField(name: textFieldName, key: textFieldKey);
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
 
         textFieldKey.currentState?.setValue('test');
@@ -329,7 +357,9 @@ void main() {
 
         expect(textFieldKey.currentState?.value, equals(initialValue));
       });
-      testWidgets('Should reset custom error when invalidate field and then reset', (tester) async {
+      testWidgets(
+          'Should reset custom error when invalidate field and then reset',
+          (tester) async {
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
         const textFieldName = 'text';
         const errorTextField = 'error text field';

--- a/test/src/form_builder_field_test.dart
+++ b/test/src/form_builder_field_test.dart
@@ -7,8 +7,7 @@ import '../form_builder_tester.dart';
 void main() {
   group('FormBuilderField -', () {
     group('custom error -', () {
-      testWidgets('Should show custom error when invalidate field',
-          (tester) async {
+      testWidgets('Should show custom error when invalidate field', (tester) async {
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
         const textFieldName = 'text2';
         const errorTextField = 'error text field';
@@ -42,9 +41,7 @@ void main() {
 
         expect(textFieldKey.currentState?.isValid, isFalse);
       });
-      testWidgets(
-          'Should valid when no has error and autovalidateMode is always',
-          (tester) async {
+      testWidgets('Should valid when no has error and autovalidateMode is always', (tester) async {
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
         const textFieldName = 'text';
         const errorTextField = 'error text field';
@@ -52,8 +49,7 @@ void main() {
           name: textFieldName,
           key: textFieldKey,
           autovalidateMode: AutovalidateMode.always,
-          validator: (value) =>
-              value == null || value.isEmpty ? errorTextField : null,
+          validator: (value) => value == null || value.isEmpty ? errorTextField : null,
         );
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
 
@@ -65,9 +61,7 @@ void main() {
 
         expect(textFieldKey.currentState?.isValid, isTrue);
       });
-      testWidgets(
-          'Should invalid when has error and autovalidateMode is always',
-          (tester) async {
+      testWidgets('Should invalid when has error and autovalidateMode is always', (tester) async {
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
         const textFieldName = 'text';
         const errorTextField = 'error text field';
@@ -75,8 +69,7 @@ void main() {
           name: textFieldName,
           key: textFieldKey,
           autovalidateMode: AutovalidateMode.always,
-          validator: (value) =>
-              value == null || value.length < 10 ? errorTextField : null,
+          validator: (value) => value == null || value.length < 10 ? errorTextField : null,
         );
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
 
@@ -107,8 +100,7 @@ void main() {
 
         expect(textFieldKey.currentState?.hasError, isTrue);
       });
-      testWidgets('Should no has errors when is empty and no has validators',
-          (tester) async {
+      testWidgets('Should no has errors when is empty and no has validators', (tester) async {
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
         const textFieldName = 'text';
         final testWidget = FormBuilderTextField(
@@ -125,16 +117,50 @@ void main() {
       });
     });
 
+    group('valueIsValid -', () {
+      testWidgets('Should value is valid when validator passes, despite set custom error', (tester) async {
+        final textFieldKey = GlobalKey<FormBuilderFieldState>();
+        const textFieldName = 'text';
+        const errorTextField = 'error text field';
+        final testWidget = FormBuilderTextField(
+          name: textFieldName,
+          key: textFieldKey,
+        );
+        await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+        // Set custom error
+        textFieldKey.currentState?.invalidate(errorTextField);
+        await tester.pumpAndSettle();
+
+        expect(textFieldKey.currentState?.valueIsValid, isTrue);
+      });
+    });
+
+    group('valueHasError -', () {
+      testWidgets('Should value is invalid when validator passes', (tester) async {
+        final textFieldKey = GlobalKey<FormBuilderFieldState>();
+        const textFieldName = 'text';
+        const invalidValue = 'invalid';
+        final testWidget = FormBuilderTextField(
+          name: textFieldName,
+          key: textFieldKey,
+          initialValue: invalidValue,
+          validator: (value) => (value == invalidValue) ? 'error' : null,
+          autovalidateMode: AutovalidateMode.always,
+        );
+        await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+        expect(textFieldKey.currentState?.valueHasError, isTrue);
+      });
+    });
+
     group('autovalidateMode -', () {
-      testWidgets(
-          'Should show error when init form and AutovalidateMode is always',
-          (tester) async {
+      testWidgets('Should show error when init form and AutovalidateMode is always', (tester) async {
         const textFieldName = 'text4';
         const errorTextField = 'error text field';
         final testWidget = FormBuilderTextField(
           name: textFieldName,
-          validator: (value) =>
-              value == null || value.isEmpty ? errorTextField : null,
+          validator: (value) => value == null || value.isEmpty ? errorTextField : null,
           autovalidateMode: AutovalidateMode.always,
         );
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
@@ -142,9 +168,7 @@ void main() {
 
         expect(find.text(errorTextField), findsOneWidget);
       });
-      testWidgets(
-          'Should show error when AutovalidateMode is onUserInteraction and change field',
-          (tester) async {
+      testWidgets('Should show error when AutovalidateMode is onUserInteraction and change field', (tester) async {
         const textFieldName = 'text4';
         const errorTextField = 'error text field';
         final testWidget = FormBuilderTextField(
@@ -166,18 +190,15 @@ void main() {
       testWidgets('Should not dirty by default', (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
-        final testWidget =
-            FormBuilderTextField(name: textFieldName, key: textFieldKey);
+        final testWidget = FormBuilderTextField(name: textFieldName, key: textFieldKey);
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
 
         expect(textFieldKey.currentState?.isDirty, false);
       });
-      testWidgets('Should dirty when update field value by user',
-          (tester) async {
+      testWidgets('Should dirty when update field value by user', (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
-        final testWidget =
-            FormBuilderTextField(name: textFieldName, key: textFieldKey);
+        final testWidget = FormBuilderTextField(name: textFieldName, key: textFieldKey);
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
 
         final widgetFinder = find.byWidget(testWidget);
@@ -185,12 +206,10 @@ void main() {
 
         expect(textFieldKey.currentState?.isDirty, true);
       });
-      testWidgets('Should dirty when update field value by method',
-          (tester) async {
+      testWidgets('Should dirty when update field value by method', (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
-        final testWidget =
-            FormBuilderTextField(name: textFieldName, key: textFieldKey);
+        final testWidget = FormBuilderTextField(name: textFieldName, key: textFieldKey);
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
 
         textFieldKey.currentState?.setValue('test');
@@ -198,8 +217,7 @@ void main() {
 
         expect(textFieldKey.currentState?.isDirty, true);
       });
-      testWidgets('Should dirty when update field with initial value by user',
-          (tester) async {
+      testWidgets('Should dirty when update field with initial value by user', (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
         final testWidget = FormBuilderTextField(
@@ -214,8 +232,7 @@ void main() {
 
         expect(textFieldKey.currentState?.isDirty, true);
       });
-      testWidgets('Should dirty when update field with initial value by method',
-          (tester) async {
+      testWidgets('Should dirty when update field with initial value by method', (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
         final testWidget = FormBuilderTextField(
@@ -233,8 +250,7 @@ void main() {
       testWidgets('Should not dirty when reset field value', (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
-        final testWidget =
-            FormBuilderTextField(name: textFieldName, key: textFieldKey);
+        final testWidget = FormBuilderTextField(name: textFieldName, key: textFieldKey);
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
 
         textFieldKey.currentState?.setValue('test');
@@ -243,8 +259,7 @@ void main() {
 
         expect(textFieldKey.currentState?.isDirty, false);
       });
-      testWidgets('Should not dirty when reset field with initial value',
-          (tester) async {
+      testWidgets('Should not dirty when reset field with initial value', (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
         final testWidget = FormBuilderTextField(
@@ -266,8 +281,7 @@ void main() {
       testWidgets('Should not touched by default', (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
-        final testWidget =
-            FormBuilderTextField(name: textFieldName, key: textFieldKey);
+        final testWidget = FormBuilderTextField(name: textFieldName, key: textFieldKey);
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
 
         expect(textFieldKey.currentState?.isTouched, false);
@@ -275,8 +289,7 @@ void main() {
       testWidgets('Should touched when focus input', (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
-        final testWidget =
-            FormBuilderTextField(name: textFieldName, key: textFieldKey);
+        final testWidget = FormBuilderTextField(name: textFieldName, key: textFieldKey);
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
 
         final widgetFinder = find.byWidget(testWidget);
@@ -290,8 +303,7 @@ void main() {
       testWidgets('Should reset to null when call reset', (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
-        final testWidget =
-            FormBuilderTextField(name: textFieldName, key: textFieldKey);
+        final testWidget = FormBuilderTextField(name: textFieldName, key: textFieldKey);
         await tester.pumpWidget(buildTestableFieldWidget(testWidget));
 
         textFieldKey.currentState?.setValue('test');
@@ -317,9 +329,7 @@ void main() {
 
         expect(textFieldKey.currentState?.value, equals(initialValue));
       });
-      testWidgets(
-          'Should reset custom error when invalidate field and then reset',
-          (tester) async {
+      testWidgets('Should reset custom error when invalidate field and then reset', (tester) async {
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
         const textFieldName = 'text';
         const errorTextField = 'error text field';


### PR DESCRIPTION
Connection with issue(s)
Close #1348 

Connected to <NONE>

Solution description
To avoid breaking changes, implemented `valueIsValid` and `valueHasError` getters on `FormBuilderFieldState` which perform the behavior of the overridden `isValid` and `hasError` getters of `FormFieldState`.

To Do

- [x]  Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x]  Check the original issue to confirm it is fully satisfied
- [x]  Add solution description to help guide reviewers
- [x]  Add unit test to verify new or fixed behavior
- [x]  If apply, add documentation to code properties and package readme