### PR TITLE
Add itemDecoration to checkbox groups nad radio groups to add borders to checkboxes and radio buttons

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:example/sources/conditional_fields.dart';
+import 'package:example/sources/decorated_radio_checkbox.dart';
 import 'package:example/sources/dynamic_fields.dart';
 import 'package:example/sources/related_fields.dart';
 import 'package:flutter/material.dart';
@@ -135,6 +136,23 @@ class _HomePage extends StatelessWidget {
                     return const CodePage(
                       title: 'Related Fields',
                       child: RelatedFields(),
+                    );
+                  },
+                ),
+              );
+            },
+          ),
+          const Divider(),
+          ListTile(
+            title: const Text('Radio Checkbox itemDecorator'),
+            trailing: const Icon(Icons.arrow_right_sharp),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) {
+                    return const CodePage(
+                      title: 'ItemDecorators',
+                      child: DecoratedRadioCheckbox(),
                     );
                   },
                 ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,16 +18,19 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    return MaterialApp(
       title: 'Flutter FormBuilder Demo',
       debugShowCheckedModeBanner: false,
-      localizationsDelegates: [
+      localizationsDelegates: const [
         FormBuilderLocalizations.delegate,
         ...GlobalMaterialLocalizations.delegates,
         GlobalWidgetsLocalizations.delegate,
       ],
       supportedLocales: FormBuilderLocalizations.supportedLocales,
-      home: _HomePage(),
+      theme: ThemeData.light().copyWith(
+          appBarTheme: const AppBarTheme()
+              .copyWith(backgroundColor: Colors.blue.shade200)),
+      home: const _HomePage(),
     );
   }
 }

--- a/example/lib/sources/decorated_radio_checkbox.dart
+++ b/example/lib/sources/decorated_radio_checkbox.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 

--- a/example/lib/sources/decorated_radio_checkbox.dart
+++ b/example/lib/sources/decorated_radio_checkbox.dart
@@ -23,7 +23,7 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
           const SizedBox(height: 20),
           // this text appears correctly if the textScaler <> 1.0
           const Text(
-              'With itemDecoration- label is a column of Widgets - orientation: wrap - wrapSpacing 5.0',
+              'label:column of Widgets itemBorder:true orient:wrap wrapSpacing:5.0',
               textScaler: TextScaler.linear(1.01)),
           FormBuilderCheckboxGroup(
             name: 'aCheckboxGroup1',
@@ -36,7 +36,7 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
           ),
           const SizedBox(height: 20),
           const Text(
-              'With itemDecoration - label is a column of Widgets - orientation: wrap - wrapSpacing 5.0',
+              'label:column of Widgets itemBorder:true orient:wrap wrapSpacing:5.0',
               textScaler: TextScaler.linear(1.01)),
           FormBuilderCheckboxGroup(
             name: 'aCheckboxGroup2',
@@ -50,7 +50,7 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
           ),
           const SizedBox(height: 20),
           const Text(
-              'With itemDecoration - label is a column of Widgets - orientation: wrap - wrapSpacing 5.0',
+              'label:column of Widgets itemBorder:true orient:wrap wrapSpacing: 5.0',
               textScaler: TextScaler.linear(1.01)),
           FormBuilderRadioGroup(
             name: 'aRadioGroup1',
@@ -62,8 +62,7 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
                 borderRadius: BorderRadius.circular(5.0)),
           ),
           const SizedBox(height: 20),
-          const Text(
-              'With itemDecoration - label is the value - orientation: wrap - wrapSpacing 10.0',
+          const Text('label:value itemBorder:true orient:wrap wrapSpacing:10.0',
               textScaler: TextScaler.linear(1.01)),
           FormBuilderRadioGroup(
             name: 'aRadioGroup2',
@@ -83,7 +82,7 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
           ),
           const SizedBox(height: 20),
           const Text(
-              'No itemDecoration - label is the value - orientation: wrap - wrapSpacing 10.0',
+              'itemDecoration:false label:value orient:wrap wrapSpacing:10.0',
               textScaler: TextScaler.linear(1.01)),
           FormBuilderRadioGroup(
             name: 'aRadioGroup3',
@@ -91,8 +90,7 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
             wrapSpacing: 10.0,
           ),
           const SizedBox(height: 20),
-          const Text(
-              'With itemDecoration - orientation: horiz - no border - wrapSpacing 5.0',
+          const Text('orient:horiz itemBorder:false wrapSpacing:5.0',
               textScaler: TextScaler.linear(1.01)),
           FormBuilderCheckboxGroup(
             name: 'aCheckboxGroup3',
@@ -105,8 +103,7 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
                 borderRadius: BorderRadius.circular(5.0)),
           ),
           const SizedBox(height: 20),
-          const Text(
-              'With itemDecoration - orientation: vert - with border - wrapSpacing 5.0',
+          const Text('orient:vert itemBorder:true wrapSpacing:5.0',
               textScaler: TextScaler.linear(1.01)),
           FormBuilderCheckboxGroup(
             name: 'aCheckboxGroup3',
@@ -120,11 +117,11 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
           ),
           const SizedBox(height: 20),
           const Text(
-              'With itemDecoration - orientation: vert - with border - wrapSpacing 5.0',
+              'label:w/sizebox orient:vert itemBorder:true wrapSpacing:5.0',
               textScaler: TextScaler.linear(1.01)),
           FormBuilderRadioGroup(
             name: 'aRadioGroup4',
-            options: getDemoOptionsWidgets(),
+            options: getDemoOptionsWidgets(forceMinWidth: 80.0),
             wrapSpacing: 5.0,
             orientation: OptionsOrientation.vertical,
             itemDecoration: BoxDecoration(
@@ -138,24 +135,51 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
   }
 
   /// options using column of widgets for the label
-  List<FormBuilderFieldOption> getDemoOptionsWidgets() {
-    return const [
+  /// We can force a min width by creating a sized box so we don't need another parameter
+  List<FormBuilderFieldOption> getDemoOptionsWidgets({forceMinWidth = 0.0}) {
+    return [
       FormBuilderFieldOption(
-          value: "airplane",
-          child: Column(
-            children: [Text("Airplane"), Icon(Icons.airplanemode_on)],
-          )),
+        value: "airplane",
+        child: Container(
+            padding: const EdgeInsets.all(5.0),
+            child: Column(
+              children: [
+                const Text("Airplane"),
+                const Icon(Icons.airplanemode_on),
+                SizedBox(width: forceMinWidth, height: 0.0),
+              ],
+            )),
+      ),
       FormBuilderFieldOption(
-          value: "fire-truck",
-          child:
-              Column(children: [Text("Fire Truck"), Icon(Icons.fire_truck)])),
+        value: "fire-truck",
+        child: Container(
+            padding: const EdgeInsets.all(5.0),
+            child: Column(children: [
+              const Text("Fire Truck"),
+              const Icon(Icons.fire_truck),
+              SizedBox(width: forceMinWidth, height: 0.0),
+            ])),
+      ),
       FormBuilderFieldOption(
-          value: "bus-alert",
-          child: Column(children: [Text("Bus Alert"), Icon(Icons.bus_alert)])),
+        value: "bus-alert",
+        child: Container(
+            padding: const EdgeInsets.all(5.0),
+            child: Column(children: [
+              const Text("Bus Alert"),
+              const Icon(Icons.bus_alert),
+              SizedBox(width: forceMinWidth, height: 0.0),
+            ])),
+      ),
       FormBuilderFieldOption(
-          value: "firetruck",
-          child:
-              Column(children: [Text("Motorcycle"), Icon(Icons.motorcycle)])),
+        value: "firetruck",
+        child: Container(
+            padding: const EdgeInsets.all(5.0),
+            child: Column(children: [
+              const Text("Motorcycle"),
+              const Icon(Icons.motorcycle),
+              SizedBox(width: forceMinWidth, height: 0.0),
+            ])),
+      ),
     ];
   }
 

--- a/example/lib/sources/decorated_radio_checkbox.dart
+++ b/example/lib/sources/decorated_radio_checkbox.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+
+class DecoratedRadioCheckbox extends StatefulWidget {
+  const DecoratedRadioCheckbox({Key? key}) : super(key: key);
+
+  @override
+  State<DecoratedRadioCheckbox> createState() => _DecoratedRadioCheckboxState();
+}
+
+class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
+  final _formKey = GlobalKey<FormBuilderState>();
+  int? option;
+
+  @override
+  Widget build(BuildContext context) {
+    return FormBuilder(
+      key: _formKey,
+      child: Column(
+        children: <Widget>[
+          const SizedBox(height: 20),
+          FormBuilderCheckboxGroup(
+            name: 'aCheckboxGroup',
+            options: getDemoOptionsWidgets(),
+            wrapSpacing: 5.0,
+            itemDecoration: BoxDecoration(
+                border: Border.all(color: Colors.blueAccent),
+                borderRadius: BorderRadius.circular(5.0)),
+          ),
+          const SizedBox(height: 20),
+          FormBuilderCheckboxGroup(
+            name: 'aCheckboxGroup',
+            options: getDemoOptionsWidgets(),
+            wrapSpacing: 5.0,
+            controlAffinity: ControlAffinity.trailing,
+            itemDecoration: BoxDecoration(
+                border: Border.all(color: Colors.blueAccent),
+                borderRadius: BorderRadius.circular(5.0)),
+          ),
+          const SizedBox(height: 20),
+          FormBuilderRadioGroup(
+            name: 'aRadioGroup',
+            options: getDemoOptionsWidgets(),
+            wrapSpacing: 5.0,
+            itemDecoration: BoxDecoration(
+                border: Border.all(color: Colors.blueAccent),
+                borderRadius: BorderRadius.circular(5.0)),
+          ),
+          const SizedBox(height: 20),
+          FormBuilderRadioGroup(
+            name: 'aRadioGroup2',
+            options: getDemoOptions(),
+            wrapSpacing: 5.0,
+            itemDecoration: BoxDecoration(
+                border: Border.all(color: Colors.blueAccent),
+                borderRadius: BorderRadius.circular(5.0)),
+          ),
+          const SizedBox(height: 20),
+        ],
+      ),
+    );
+  }
+
+  List<FormBuilderFieldOption> getDemoOptionsWidgets() {
+    return const [
+      FormBuilderFieldOption(
+          value: "airplane",
+          child: Column(
+            children: [Text("Airplane"), Icon(Icons.airplanemode_on)],
+          )),
+      FormBuilderFieldOption(
+          value: "fire-truck",
+          child:
+              Column(children: [Text("Fire Truck"), Icon(Icons.fire_truck)])),
+      FormBuilderFieldOption(
+          value: "bus-alert",
+          child: Column(children: [Text("Bus Alert"), Icon(Icons.bus_alert)])),
+      FormBuilderFieldOption(
+          value: "firetruck",
+          child:
+              Column(children: [Text("Motorcycle"), Icon(Icons.motorcycle)])),
+    ];
+  }
+
+  List<FormBuilderFieldOption> getDemoOptions() {
+    return const [
+      FormBuilderFieldOption(
+        value: "airplane",
+      ),
+      FormBuilderFieldOption(
+        value: "fire-truck",
+      ),
+      FormBuilderFieldOption(
+        value: "bus-alert",
+      ),
+      FormBuilderFieldOption(
+        value: "firetruck",
+      ),
+    ];
+  }
+}

--- a/example/lib/sources/decorated_radio_checkbox.dart
+++ b/example/lib/sources/decorated_radio_checkbox.dart
@@ -86,9 +86,8 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
             wrapSpacing: 10.0,
           ),
           const SizedBox(height: 20),
-          const SizedBox(height: 20),
           const Text(
-              'With itemDecoration - orientation:horizontal - orientation: horiz - wrapSpacing 5.0',
+              'With itemDecoration - orientation: horiz - no border - wrapSpacing 5.0',
               textScaler: TextScaler.linear(1.01)),
           FormBuilderCheckboxGroup(
             name: 'aCheckboxGroup3',
@@ -96,14 +95,13 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
             wrapSpacing: 5.0,
             orientation: OptionsOrientation.horizontal,
             itemDecoration: BoxDecoration(
-                gradient:
-                    const LinearGradient(colors: [Colors.red, Colors.white]),
-                border: Border.all(color: Colors.blueAccent),
+                color: Colors.grey.shade300,
+//                border: Border.all(color: Colors.blueAccent),
                 borderRadius: BorderRadius.circular(5.0)),
           ),
           const SizedBox(height: 20),
           const Text(
-              'With itemDecoration - orientation:vertical - orientation: vert - wrapSpacing 5.0',
+              'With itemDecoration - orientation: vert - with border - wrapSpacing 5.0',
               textScaler: TextScaler.linear(1.01)),
           FormBuilderCheckboxGroup(
             name: 'aCheckboxGroup3',
@@ -111,11 +109,21 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
             wrapSpacing: 5.0,
             orientation: OptionsOrientation.vertical,
             itemDecoration: BoxDecoration(
-                gradient: const LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    colors: [Colors.red, Colors.white]),
                 color: Colors.red.shade100,
+                border: Border.all(color: Colors.blueAccent),
+                borderRadius: BorderRadius.circular(5.0)),
+          ),
+          const SizedBox(height: 20),
+          const Text(
+              'With itemDecoration - orientation: vert - with border - wrapSpacing 5.0',
+              textScaler: TextScaler.linear(1.01)),
+          FormBuilderRadioGroup(
+            name: 'aRadioGroup4',
+            options: getDemoOptionsWidgets(),
+            wrapSpacing: 5.0,
+            orientation: OptionsOrientation.vertical,
+            itemDecoration: BoxDecoration(
+                color: Colors.lightBlue.shade100,
                 border: Border.all(color: Colors.blueAccent),
                 borderRadius: BorderRadius.circular(5.0)),
           ),

--- a/example/lib/sources/decorated_radio_checkbox.dart
+++ b/example/lib/sources/decorated_radio_checkbox.dart
@@ -71,6 +71,13 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
             name: 'aRadioGroup2',
             options: getDemoOptions(),
             wrapSpacing: 10.0,
+            wrapRunSpacing: 10.0,
+            decoration: InputDecoration(
+                border: const OutlineInputBorder(),
+                contentPadding: const EdgeInsets.only(left: 20, top: 40),
+                labelText: 'hello there',
+                icon: const Icon(Icons.access_alarm_outlined),
+                fillColor: Colors.red.shade200),
             itemDecoration: BoxDecoration(
                 color: Colors.blueGrey.shade200,
                 border: Border.all(color: Colors.blueAccent),

--- a/example/lib/sources/decorated_radio_checkbox.dart
+++ b/example/lib/sources/decorated_radio_checkbox.dart
@@ -19,8 +19,10 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
       child: Column(
         children: <Widget>[
           const SizedBox(height: 20),
+          // this text appears correctly if the textScaler <> 1.0
           const Text(
-              'Checkboxes: control leading - label area is a column of Widgets - wrapSpacing 5.0'),
+              'Checkboxes: control leading - with itemDecoration- label area is a column of Widgets - wrapSpacing 5.0',
+              textScaler: TextScaler.linear(1.01)),
           FormBuilderCheckboxGroup(
             name: 'aCheckboxGroup',
             options: getDemoOptionsWidgets(),
@@ -31,7 +33,8 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
           ),
           const SizedBox(height: 20),
           const Text(
-              'Checkboxes: control trailing - label area is a column of Widgets - wrapSpacing 5.0'),
+              'Checkboxes: control trailing - with itemDecoration - label area is a column of Widgets - wrapSpacing 5.0',
+              textScaler: TextScaler.linear(1.01)),
           FormBuilderCheckboxGroup(
             name: 'aCheckboxGroup',
             options: getDemoOptionsWidgets(),
@@ -43,7 +46,8 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
           ),
           const SizedBox(height: 20),
           const Text(
-              'Radio: control leading - label area is a column of Widgets - wrapSpacing 5.0'),
+              'Radio: control leading - with itemDecoration - label area is a column of Widgets - wrapSpacing 5.0',
+              textScaler: TextScaler.linear(1.01)),
           FormBuilderRadioGroup(
             name: 'aRadioGroup',
             options: getDemoOptionsWidgets(),
@@ -54,7 +58,8 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
           ),
           const SizedBox(height: 20),
           const Text(
-              'Radio: control leading - label area just the value - wrapSpacing 10.0'),
+              'Radio: control leading - with itemDecoration - label area just the value - wrapSpacing 10.0',
+              textScaler: TextScaler.linear(1.01)),
           FormBuilderRadioGroup(
             name: 'aRadioGroup2',
             options: getDemoOptions(),
@@ -62,6 +67,16 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
             itemDecoration: BoxDecoration(
                 border: Border.all(color: Colors.blueAccent),
                 borderRadius: BorderRadius.circular(5.0)),
+          ),
+          const SizedBox(height: 20),
+          const Text(
+              'Radio: control leading - no itemDecoration - label area just the value - wrapSpacing 10.0',
+              textScaler: TextScaler.linear(1.01)),
+
+          FormBuilderRadioGroup(
+            name: 'aRadioGroup2',
+            options: getDemoOptions(),
+            wrapSpacing: 10.0,
           ),
           const SizedBox(height: 20),
         ],

--- a/example/lib/sources/decorated_radio_checkbox.dart
+++ b/example/lib/sources/decorated_radio_checkbox.dart
@@ -19,6 +19,8 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
       child: Column(
         children: <Widget>[
           const SizedBox(height: 20),
+          const Text(
+              'Checkboxes: control leading - label area is a column of Widgets - wrapSpacing 5.0'),
           FormBuilderCheckboxGroup(
             name: 'aCheckboxGroup',
             options: getDemoOptionsWidgets(),
@@ -28,6 +30,8 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
                 borderRadius: BorderRadius.circular(5.0)),
           ),
           const SizedBox(height: 20),
+          const Text(
+              'Checkboxes: control trailing - label area is a column of Widgets - wrapSpacing 5.0'),
           FormBuilderCheckboxGroup(
             name: 'aCheckboxGroup',
             options: getDemoOptionsWidgets(),
@@ -38,6 +42,8 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
                 borderRadius: BorderRadius.circular(5.0)),
           ),
           const SizedBox(height: 20),
+          const Text(
+              'Radio: control leading - label area is a column of Widgets - wrapSpacing 5.0'),
           FormBuilderRadioGroup(
             name: 'aRadioGroup',
             options: getDemoOptionsWidgets(),
@@ -47,10 +53,12 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
                 borderRadius: BorderRadius.circular(5.0)),
           ),
           const SizedBox(height: 20),
+          const Text(
+              'Radio: control leading - label area just the value - wrapSpacing 10.0'),
           FormBuilderRadioGroup(
             name: 'aRadioGroup2',
             options: getDemoOptions(),
-            wrapSpacing: 5.0,
+            wrapSpacing: 10.0,
             itemDecoration: BoxDecoration(
                 border: Border.all(color: Colors.blueAccent),
                 borderRadius: BorderRadius.circular(5.0)),

--- a/example/lib/sources/decorated_radio_checkbox.dart
+++ b/example/lib/sources/decorated_radio_checkbox.dart
@@ -1,6 +1,9 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
+/// Demonstrates the use of itemDecorators to wrap a box around selection items
 class DecoratedRadioCheckbox extends StatefulWidget {
   const DecoratedRadioCheckbox({Key? key}) : super(key: key);
 
@@ -14,76 +17,114 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
 
   @override
   Widget build(BuildContext context) {
-    return FormBuilder(
+    return SingleChildScrollView(
+        child: FormBuilder(
       key: _formKey,
       child: Column(
         children: <Widget>[
           const SizedBox(height: 20),
           // this text appears correctly if the textScaler <> 1.0
           const Text(
-              'Checkboxes: control leading - with itemDecoration- label area is a column of Widgets - wrapSpacing 5.0',
+              'With itemDecoration- label is a column of Widgets - orientation: wrap - wrapSpacing 5.0',
               textScaler: TextScaler.linear(1.01)),
           FormBuilderCheckboxGroup(
-            name: 'aCheckboxGroup',
+            name: 'aCheckboxGroup1',
             options: getDemoOptionsWidgets(),
             wrapSpacing: 5.0,
             itemDecoration: BoxDecoration(
-                border: Border.all(color: Colors.blueAccent),
+                color: Colors.orange.shade200,
+                border: Border.all(color: Colors.blue),
                 borderRadius: BorderRadius.circular(5.0)),
           ),
           const SizedBox(height: 20),
           const Text(
-              'Checkboxes: control trailing - with itemDecoration - label area is a column of Widgets - wrapSpacing 5.0',
+              'With itemDecoration - label is a column of Widgets - orientation: wrap - wrapSpacing 5.0',
               textScaler: TextScaler.linear(1.01)),
           FormBuilderCheckboxGroup(
-            name: 'aCheckboxGroup',
+            name: 'aCheckboxGroup2',
             options: getDemoOptionsWidgets(),
             wrapSpacing: 5.0,
             controlAffinity: ControlAffinity.trailing,
             itemDecoration: BoxDecoration(
+                color: Colors.amber.shade200,
                 border: Border.all(color: Colors.blueAccent),
                 borderRadius: BorderRadius.circular(5.0)),
           ),
           const SizedBox(height: 20),
           const Text(
-              'Radio: control leading - with itemDecoration - label area is a column of Widgets - wrapSpacing 5.0',
+              'With itemDecoration - label is a column of Widgets - orientation: wrap - wrapSpacing 5.0',
               textScaler: TextScaler.linear(1.01)),
           FormBuilderRadioGroup(
-            name: 'aRadioGroup',
+            name: 'aRadioGroup1',
             options: getDemoOptionsWidgets(),
             wrapSpacing: 5.0,
             itemDecoration: BoxDecoration(
+                color: Colors.green.shade200,
                 border: Border.all(color: Colors.blueAccent),
                 borderRadius: BorderRadius.circular(5.0)),
           ),
           const SizedBox(height: 20),
           const Text(
-              'Radio: control leading - with itemDecoration - label area just the value - wrapSpacing 10.0',
+              'With itemDecoration - label is the value - orientation: wrap - wrapSpacing 10.0',
               textScaler: TextScaler.linear(1.01)),
           FormBuilderRadioGroup(
             name: 'aRadioGroup2',
             options: getDemoOptions(),
             wrapSpacing: 10.0,
             itemDecoration: BoxDecoration(
+                color: Colors.blueGrey.shade200,
                 border: Border.all(color: Colors.blueAccent),
                 borderRadius: BorderRadius.circular(5.0)),
           ),
           const SizedBox(height: 20),
           const Text(
-              'Radio: control leading - no itemDecoration - label area just the value - wrapSpacing 10.0',
+              'No itemDecoration - label is the value - orientation: wrap - wrapSpacing 10.0',
               textScaler: TextScaler.linear(1.01)),
-
           FormBuilderRadioGroup(
-            name: 'aRadioGroup2',
+            name: 'aRadioGroup3',
             options: getDemoOptions(),
             wrapSpacing: 10.0,
           ),
           const SizedBox(height: 20),
+          const SizedBox(height: 20),
+          const Text(
+              'With itemDecoration - orientation:horizontal - orientation: horiz - wrapSpacing 5.0',
+              textScaler: TextScaler.linear(1.01)),
+          FormBuilderCheckboxGroup(
+            name: 'aCheckboxGroup3',
+            options: getDemoOptionsWidgets(),
+            wrapSpacing: 5.0,
+            orientation: OptionsOrientation.horizontal,
+            itemDecoration: BoxDecoration(
+                gradient:
+                    const LinearGradient(colors: [Colors.red, Colors.white]),
+                border: Border.all(color: Colors.blueAccent),
+                borderRadius: BorderRadius.circular(5.0)),
+          ),
+          const SizedBox(height: 20),
+          const Text(
+              'With itemDecoration - orientation:vertical - orientation: vert - wrapSpacing 5.0',
+              textScaler: TextScaler.linear(1.01)),
+          FormBuilderCheckboxGroup(
+            name: 'aCheckboxGroup3',
+            options: getDemoOptionsWidgets(),
+            wrapSpacing: 5.0,
+            orientation: OptionsOrientation.vertical,
+            itemDecoration: BoxDecoration(
+                gradient: const LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [Colors.red, Colors.white]),
+                color: Colors.red.shade100,
+                border: Border.all(color: Colors.blueAccent),
+                borderRadius: BorderRadius.circular(5.0)),
+          ),
         ],
       ),
-    );
+    ));
   }
 
+  /// options using column of widgets for the label
   List<FormBuilderFieldOption> getDemoOptionsWidgets() {
     return const [
       FormBuilderFieldOption(
@@ -105,6 +146,7 @@ class _DecoratedRadioCheckboxState extends State<DecoratedRadioCheckbox> {
     ];
   }
 
+  /// opens using just values
   List<FormBuilderFieldOption> getDemoOptions() {
     return const [
       FormBuilderFieldOption(

--- a/lib/src/fields/form_builder_checkbox_group.dart
+++ b/lib/src/fields/form_builder_checkbox_group.dart
@@ -25,7 +25,9 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderFieldDecoration<List<T>> {
   final ControlAffinity controlAffinity;
   final OptionsOrientation orientation;
 
-  /// A decorator that is applied to each select item - ex: box the item
+  /// A BoxDecoration that is added to each item if provided
+  /// WrapSpacing is reused for the the padding inside the itemDecoration
+  /// on the side opposite from the control
   final BoxDecoration? itemDecoration;
 
   /// Creates a list of Checkboxes for selecting multiple options

--- a/lib/src/fields/form_builder_checkbox_group.dart
+++ b/lib/src/fields/form_builder_checkbox_group.dart
@@ -25,6 +25,9 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderFieldDecoration<List<T>> {
   final ControlAffinity controlAffinity;
   final OptionsOrientation orientation;
 
+  /// A decorator that is applied to each select item - ex: box the item
+  final BoxDecoration? itemDecoration;
+
   /// Creates a list of Checkboxes for selecting multiple options
   FormBuilderCheckboxGroup({
     super.key,
@@ -60,6 +63,7 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderFieldDecoration<List<T>> {
     this.separator,
     this.controlAffinity = ControlAffinity.leading,
     this.orientation = OptionsOrientation.wrap,
+    this.itemDecoration,
   }) : super(
           builder: (FormFieldState<List<T>?> field) {
             final state = field as _FormBuilderCheckboxGroupState<T>;
@@ -93,6 +97,7 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderFieldDecoration<List<T>> {
                 wrapVerticalDirection: wrapVerticalDirection,
                 separator: separator,
                 controlAffinity: controlAffinity,
+                itemDecoration: itemDecoration,
               ),
             );
           },

--- a/lib/src/fields/form_builder_radio_group.dart
+++ b/lib/src/fields/form_builder_radio_group.dart
@@ -22,6 +22,9 @@ class FormBuilderRadioGroup<T> extends FormBuilderFieldDecoration<T> {
   final WrapAlignment wrapRunAlignment;
   final WrapCrossAlignment wrapCrossAxisAlignment;
 
+  /// A decorator that is applied to each select item - ex: box the item
+  final BoxDecoration? itemDecoration;
+
   /// Creates field to select one value from a list of Radio Widgets
   FormBuilderRadioGroup({
     super.autovalidateMode = AutovalidateMode.disabled,
@@ -54,6 +57,7 @@ class FormBuilderRadioGroup<T> extends FormBuilderFieldDecoration<T> {
     super.valueTransformer,
     super.onReset,
     super.restorationId,
+    this.itemDecoration,
   }) : super(
           builder: (FormFieldState<T?> field) {
             final state = field as _FormBuilderRadioGroupState<T>;
@@ -84,6 +88,7 @@ class FormBuilderRadioGroup<T> extends FormBuilderFieldDecoration<T> {
                 wrapSpacing: wrapSpacing,
                 wrapTextDirection: wrapTextDirection,
                 wrapVerticalDirection: wrapVerticalDirection,
+                itemDecoration: itemDecoration,
               ),
             );
           },

--- a/lib/src/fields/form_builder_radio_group.dart
+++ b/lib/src/fields/form_builder_radio_group.dart
@@ -22,7 +22,9 @@ class FormBuilderRadioGroup<T> extends FormBuilderFieldDecoration<T> {
   final WrapAlignment wrapRunAlignment;
   final WrapCrossAlignment wrapCrossAxisAlignment;
 
-  /// A decorator that is applied to each select item - ex: box the item
+  /// A BoxDecoration that is added to each item if provided
+  /// WrapSpacing is reused for the the padding inside the itemDecoration
+  /// on the side opposite from the control
   final BoxDecoration? itemDecoration;
 
   /// Creates field to select one value from a list of Radio Widgets

--- a/lib/src/widgets/grouped_checkbox.dart
+++ b/lib/src/widgets/grouped_checkbox.dart
@@ -181,7 +181,9 @@ class GroupedCheckbox<T> extends StatelessWidget {
 
   final ControlAffinity controlAffinity;
 
-  /// will be added to each item if provided
+  /// A BoxDecoration that is added to each item if provided
+  /// WrapSpacing is reused for the the padding inside the itemDecoration
+  /// on the side opposite from the control
   final BoxDecoration? itemDecoration;
 
   const GroupedCheckbox({
@@ -304,6 +306,11 @@ class GroupedCheckbox<T> extends StatelessWidget {
 
     if (this.itemDecoration != null) {
       compositeItem = Container(
+        padding: EdgeInsets.only(
+            left:
+                controlAffinity == ControlAffinity.leading ? 0.0 : wrapSpacing,
+            right:
+                controlAffinity == ControlAffinity.leading ? wrapSpacing : 0.0),
         decoration: this.itemDecoration,
         child: compositeItem,
       );

--- a/lib/src/widgets/grouped_checkbox.dart
+++ b/lib/src/widgets/grouped_checkbox.dart
@@ -182,7 +182,9 @@ class GroupedCheckbox<T> extends StatelessWidget {
   final ControlAffinity controlAffinity;
 
   /// A BoxDecoration that is added to each item if provided
-  /// WrapSpacing is reused for the the padding inside the itemDecoration
+  /// [wrapSpacing] is reused for the the padding inside the [itemDecoration].
+  /// [wrapSpacing] is used as inter-item bottom margin for [Orientation.vertical]
+  /// [wrapSpacing] is used as inter-item right margin for [Orientation.horizontal].
   /// on the side opposite from the control
   final BoxDecoration? itemDecoration;
 
@@ -306,12 +308,17 @@ class GroupedCheckbox<T> extends StatelessWidget {
 
     if (this.itemDecoration != null) {
       compositeItem = Container(
-        padding: EdgeInsets.only(
-            left:
-                controlAffinity == ControlAffinity.leading ? 0.0 : wrapSpacing,
-            right:
-                controlAffinity == ControlAffinity.leading ? wrapSpacing : 0.0),
         decoration: this.itemDecoration,
+        padding: EdgeInsets.only(
+          left: controlAffinity == ControlAffinity.leading ? 0.0 : wrapSpacing,
+          right: controlAffinity == ControlAffinity.leading ? wrapSpacing : 0.0,
+        ),
+        margin: EdgeInsets.only(
+          bottom:
+              orientation == OptionsOrientation.vertical ? wrapSpacing : 0.0,
+          right:
+              orientation == OptionsOrientation.horizontal ? wrapSpacing : 0.0,
+        ),
         child: compositeItem,
       );
     }

--- a/lib/src/widgets/grouped_checkbox.dart
+++ b/lib/src/widgets/grouped_checkbox.dart
@@ -181,6 +181,9 @@ class GroupedCheckbox<T> extends StatelessWidget {
 
   final ControlAffinity controlAffinity;
 
+  /// will be added to each item if provided
+  final BoxDecoration? itemDecoration;
+
   const GroupedCheckbox({
     super.key,
     required this.options,
@@ -205,13 +208,14 @@ class GroupedCheckbox<T> extends StatelessWidget {
     this.separator,
     this.controlAffinity = ControlAffinity.leading,
     this.visualDensity,
+    this.itemDecoration,
   });
 
   @override
   Widget build(BuildContext context) {
     final widgetList = <Widget>[];
     for (var i = 0; i < options.length; i++) {
-      widgetList.add(item(i));
+      widgetList.add(buildItem(i));
     }
     Widget finalWidget;
     if (orientation == OptionsOrientation.vertical) {
@@ -249,7 +253,8 @@ class GroupedCheckbox<T> extends StatelessWidget {
     return finalWidget;
   }
 
-  Widget item(int index) {
+  /// the composite of all the components for the option at index
+  Widget buildItem(int index) {
     final option = options[index];
     final optionValue = option.value;
     final isOptionDisabled = true == disabled?.contains(optionValue);
@@ -287,7 +292,7 @@ class GroupedCheckbox<T> extends StatelessWidget {
       child: option,
     );
 
-    return Row(
+    Widget compositeItem = Row(
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
         if (controlAffinity == ControlAffinity.leading) control,
@@ -296,5 +301,14 @@ class GroupedCheckbox<T> extends StatelessWidget {
         if (separator != null && index != options.length - 1) separator!,
       ],
     );
+
+    if (this.itemDecoration != null) {
+      compositeItem = Container(
+        decoration: this.itemDecoration,
+        child: compositeItem,
+      );
+    }
+
+    return compositeItem;
   }
 }

--- a/lib/src/widgets/grouped_checkbox.dart
+++ b/lib/src/widgets/grouped_checkbox.dart
@@ -182,7 +182,6 @@ class GroupedCheckbox<T> extends StatelessWidget {
   final ControlAffinity controlAffinity;
 
   /// A BoxDecoration that is added to each item if provided
-  /// [wrapSpacing] is reused for the the padding inside the [itemDecoration].
   /// [wrapSpacing] is used as inter-item bottom margin for [Orientation.vertical]
   /// [wrapSpacing] is used as inter-item right margin for [Orientation.horizontal].
   /// on the side opposite from the control
@@ -309,10 +308,6 @@ class GroupedCheckbox<T> extends StatelessWidget {
     if (this.itemDecoration != null) {
       compositeItem = Container(
         decoration: this.itemDecoration,
-        padding: EdgeInsets.only(
-          left: controlAffinity == ControlAffinity.leading ? 0.0 : wrapSpacing,
-          right: controlAffinity == ControlAffinity.leading ? wrapSpacing : 0.0,
-        ),
         margin: EdgeInsets.only(
           bottom:
               orientation == OptionsOrientation.vertical ? wrapSpacing : 0.0,

--- a/lib/src/widgets/grouped_radio.dart
+++ b/lib/src/widgets/grouped_radio.dart
@@ -172,7 +172,9 @@ class GroupedRadio<T> extends StatefulWidget {
 
   final ControlAffinity controlAffinity;
 
-  /// will be added to each item if provided
+  /// A BoxDecoration that is added to each item if provided
+  /// WrapSpacing is reused for the the padding inside the itemDecoration
+  /// on the side opposite from the control
   final BoxDecoration? itemDecoration;
 
   const GroupedRadio({
@@ -297,6 +299,13 @@ class _GroupedRadioState<T> extends State<GroupedRadio<T?>> {
     if (widget.itemDecoration != null) {
       compositeItem = Container(
         decoration: widget.itemDecoration,
+        padding: EdgeInsets.only(
+            left: widget.controlAffinity == ControlAffinity.leading
+                ? 0.0
+                : widget.wrapSpacing,
+            right: widget.controlAffinity == ControlAffinity.leading
+                ? widget.wrapSpacing
+                : 0.0),
         child: compositeItem,
       );
     }

--- a/lib/src/widgets/grouped_radio.dart
+++ b/lib/src/widgets/grouped_radio.dart
@@ -173,7 +173,6 @@ class GroupedRadio<T> extends StatefulWidget {
   final ControlAffinity controlAffinity;
 
   /// A BoxDecoration that is added to each item if provided
-  /// [wrapSpacing] is reused for the the padding inside the [itemDecoration].
   /// [wrapSpacing] is used as inter-item bottom margin for [Orientation.vertical]
   /// [wrapSpacing] is used as inter-item right margin for [Orientation.horizontal].
   /// on the side opposite from the control
@@ -301,13 +300,6 @@ class _GroupedRadioState<T> extends State<GroupedRadio<T?>> {
     if (widget.itemDecoration != null) {
       compositeItem = Container(
         decoration: widget.itemDecoration,
-        padding: EdgeInsets.only(
-            left: widget.controlAffinity == ControlAffinity.leading
-                ? 0.0
-                : widget.wrapSpacing,
-            right: widget.controlAffinity == ControlAffinity.leading
-                ? widget.wrapSpacing
-                : 0.0),
         margin: EdgeInsets.only(
           bottom: widget.orientation == OptionsOrientation.vertical
               ? widget.wrapSpacing

--- a/lib/src/widgets/grouped_radio.dart
+++ b/lib/src/widgets/grouped_radio.dart
@@ -173,7 +173,9 @@ class GroupedRadio<T> extends StatefulWidget {
   final ControlAffinity controlAffinity;
 
   /// A BoxDecoration that is added to each item if provided
-  /// WrapSpacing is reused for the the padding inside the itemDecoration
+  /// [wrapSpacing] is reused for the the padding inside the [itemDecoration].
+  /// [wrapSpacing] is used as inter-item bottom margin for [Orientation.vertical]
+  /// [wrapSpacing] is used as inter-item right margin for [Orientation.horizontal].
   /// on the side opposite from the control
   final BoxDecoration? itemDecoration;
 
@@ -306,6 +308,14 @@ class _GroupedRadioState<T> extends State<GroupedRadio<T?>> {
             right: widget.controlAffinity == ControlAffinity.leading
                 ? widget.wrapSpacing
                 : 0.0),
+        margin: EdgeInsets.only(
+          bottom: widget.orientation == OptionsOrientation.vertical
+              ? widget.wrapSpacing
+              : 0.0,
+          right: widget.orientation == OptionsOrientation.horizontal
+              ? widget.wrapSpacing
+              : 0.0,
+        ),
         child: compositeItem,
       );
     }

--- a/lib/src/widgets/grouped_radio.dart
+++ b/lib/src/widgets/grouped_radio.dart
@@ -172,6 +172,9 @@ class GroupedRadio<T> extends StatefulWidget {
 
   final ControlAffinity controlAffinity;
 
+  /// will be added to each item if provided
+  final BoxDecoration? itemDecoration;
+
   const GroupedRadio({
     super.key,
     required this.options,
@@ -193,6 +196,7 @@ class GroupedRadio<T> extends StatefulWidget {
     this.wrapVerticalDirection = VerticalDirection.down,
     this.separator,
     this.controlAffinity = ControlAffinity.leading,
+    this.itemDecoration,
   });
 
   @override
@@ -204,7 +208,7 @@ class _GroupedRadioState<T> extends State<GroupedRadio<T?>> {
   Widget build(BuildContext context) {
     final widgetList = <Widget>[];
     for (int i = 0; i < widget.options.length; i++) {
-      widgetList.add(_buildRadioButton(i));
+      widgetList.add(buildItem(i));
     }
 
     switch (widget.orientation) {
@@ -239,7 +243,8 @@ class _GroupedRadioState<T> extends State<GroupedRadio<T?>> {
     }
   }
 
-  Widget _buildRadioButton(int index) {
+  /// the composite of all the components for the option at index
+  Widget buildItem(int index) {
     final option = widget.options[index];
     final optionValue = option.value;
     final isOptionDisabled = true == widget.disabled?.contains(optionValue);
@@ -266,7 +271,7 @@ class _GroupedRadioState<T> extends State<GroupedRadio<T?>> {
       child: option,
     );
 
-    return Column(
+    Widget compositeItem = Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -288,5 +293,14 @@ class _GroupedRadioState<T> extends State<GroupedRadio<T?>> {
           widget.separator!,
       ],
     );
+
+    if (widget.itemDecoration != null) {
+      compositeItem = Container(
+        decoration: widget.itemDecoration,
+        child: compositeItem,
+      );
+    }
+
+    return compositeItem;
   }
 }

--- a/test/form_builder_checkbox_group_test.dart
+++ b/test/form_builder_checkbox_group_test.dart
@@ -29,53 +29,6 @@ void main() {
     expect(formValue(widgetName), equals(const [1, 3]));
   });
 
-  testWidgets('FormBuilderCheckboxGroup -- decoration control',
-      (WidgetTester tester) async {
-    const widgetName = 'cbg1';
-    final testWidget = FormBuilderCheckboxGroup<int>(
-      name: widgetName,
-      wrapSpacing: 10.0,
-      options: const [
-        FormBuilderFieldOption(key: ValueKey('1'), value: 1),
-        FormBuilderFieldOption(key: ValueKey('2'), value: 2),
-      ],
-      itemDecoration:
-          BoxDecoration(border: Border.all(color: Colors.blueAccent)),
-    );
-    await tester.pumpWidget(buildTestableFieldWidget(testWidget));
-
-    // this is a brittle test knowing how we use container for a border
-    // there is one container for each option
-    expect(find.byType(Container), findsExactly(2));
-    // same as wrapSpacing
-    Container foo = tester.firstWidget(find.byType(Container));
-    expect(foo.padding, const EdgeInsets.only(right: 10.0));
-  });
-
-  testWidgets('FormBuilderCheckboxGroup -- decoration control following',
-      (WidgetTester tester) async {
-    const widgetName = 'cbg1';
-    final testWidget = FormBuilderCheckboxGroup<int>(
-      name: widgetName,
-      controlAffinity: ControlAffinity.trailing,
-      wrapSpacing: 10.0,
-      options: const [
-        FormBuilderFieldOption(key: ValueKey('1'), value: 1),
-        FormBuilderFieldOption(key: ValueKey('2'), value: 2),
-      ],
-      itemDecoration:
-          BoxDecoration(border: Border.all(color: Colors.blueAccent)),
-    );
-    await tester.pumpWidget(buildTestableFieldWidget(testWidget));
-
-    // this is a brittle test knowing how we use container for a border
-    // there is one container for each option
-    expect(find.byType(Container), findsExactly(2));
-    // same as wrapSpacing
-    Container foo = tester.firstWidget(find.byType(Container));
-    expect(foo.padding, const EdgeInsets.only(left: 10.0));
-  });
-
   testWidgets('FormBuilderCheckboxGroup -- decoration horizontal',
       (WidgetTester tester) async {
     const widgetName = 'cbg1';

--- a/test/form_builder_checkbox_group_test.dart
+++ b/test/form_builder_checkbox_group_test.dart
@@ -28,6 +28,27 @@ void main() {
     expect(formSave(), isTrue);
     expect(formValue(widgetName), equals(const [1, 3]));
   });
+
+  testWidgets('FormBuilderCheckboxGroup -- decoration',
+      (WidgetTester tester) async {
+    const widgetName = 'cbg1';
+    final testWidget = FormBuilderCheckboxGroup<int>(
+      name: widgetName,
+      options: const [
+        FormBuilderFieldOption(key: ValueKey('1'), value: 1),
+        FormBuilderFieldOption(key: ValueKey('2'), value: 2),
+        FormBuilderFieldOption(key: ValueKey('3'), value: 3),
+      ],
+      itemDecoration:
+          BoxDecoration(border: Border.all(color: Colors.blueAccent)),
+    );
+    await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+    // this is a brittle test knowing how we use container for a border
+    // there is one container for each option
+    expect(find.byType(Container), findsExactly(3));
+  });
+
   testWidgets('FormBuilderCheckboxGroup -- didChange',
       (WidgetTester tester) async {
     const fieldName = 'cbg1';

--- a/test/form_builder_checkbox_group_test.dart
+++ b/test/form_builder_checkbox_group_test.dart
@@ -29,15 +29,15 @@ void main() {
     expect(formValue(widgetName), equals(const [1, 3]));
   });
 
-  testWidgets('FormBuilderCheckboxGroup -- decoration',
+  testWidgets('FormBuilderCheckboxGroup -- decoration control',
       (WidgetTester tester) async {
     const widgetName = 'cbg1';
     final testWidget = FormBuilderCheckboxGroup<int>(
       name: widgetName,
+      wrapSpacing: 10.0,
       options: const [
         FormBuilderFieldOption(key: ValueKey('1'), value: 1),
         FormBuilderFieldOption(key: ValueKey('2'), value: 2),
-        FormBuilderFieldOption(key: ValueKey('3'), value: 3),
       ],
       itemDecoration:
           BoxDecoration(border: Border.all(color: Colors.blueAccent)),
@@ -46,7 +46,82 @@ void main() {
 
     // this is a brittle test knowing how we use container for a border
     // there is one container for each option
-    expect(find.byType(Container), findsExactly(3));
+    expect(find.byType(Container), findsExactly(2));
+    // same as wrapSpacing
+    Container foo = tester.firstWidget(find.byType(Container));
+    expect(foo.padding, const EdgeInsets.only(right: 10.0));
+  });
+
+  testWidgets('FormBuilderCheckboxGroup -- decoration control following',
+      (WidgetTester tester) async {
+    const widgetName = 'cbg1';
+    final testWidget = FormBuilderCheckboxGroup<int>(
+      name: widgetName,
+      controlAffinity: ControlAffinity.trailing,
+      wrapSpacing: 10.0,
+      options: const [
+        FormBuilderFieldOption(key: ValueKey('1'), value: 1),
+        FormBuilderFieldOption(key: ValueKey('2'), value: 2),
+      ],
+      itemDecoration:
+          BoxDecoration(border: Border.all(color: Colors.blueAccent)),
+    );
+    await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+    // this is a brittle test knowing how we use container for a border
+    // there is one container for each option
+    expect(find.byType(Container), findsExactly(2));
+    // same as wrapSpacing
+    Container foo = tester.firstWidget(find.byType(Container));
+    expect(foo.padding, const EdgeInsets.only(left: 10.0));
+  });
+
+  testWidgets('FormBuilderCheckboxGroup -- decoration horizontal',
+      (WidgetTester tester) async {
+    const widgetName = 'cbg1';
+    final testWidget = FormBuilderCheckboxGroup<int>(
+      name: widgetName,
+      orientation: OptionsOrientation.horizontal,
+      wrapSpacing: 10.0,
+      options: const [
+        FormBuilderFieldOption(key: ValueKey('1'), value: 1),
+        FormBuilderFieldOption(key: ValueKey('2'), value: 2),
+      ],
+      itemDecoration:
+          BoxDecoration(border: Border.all(color: Colors.blueAccent)),
+    );
+    await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+    // this is a brittle test knowing how we use container for a border
+    // there is one container for each option
+    expect(find.byType(Container), findsExactly(2));
+    // same as wrapSpacing
+    Container foo = tester.firstWidget(find.byType(Container));
+    expect(foo.margin, const EdgeInsets.only(right: 10.0));
+  });
+
+  testWidgets('FormBuilderCheckboxGroup -- decoration vertical',
+      (WidgetTester tester) async {
+    const widgetName = 'cbg1';
+    final testWidget = FormBuilderCheckboxGroup<int>(
+      name: widgetName,
+      orientation: OptionsOrientation.vertical,
+      wrapSpacing: 10.0,
+      options: const [
+        FormBuilderFieldOption(key: ValueKey('1'), value: 1),
+        FormBuilderFieldOption(key: ValueKey('2'), value: 2),
+      ],
+      itemDecoration:
+          BoxDecoration(border: Border.all(color: Colors.blueAccent)),
+    );
+    await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+    // this is a brittle test knowing how we use container for a border
+    // there is one container for each option
+    expect(find.byType(Container), findsExactly(2));
+    // same as wrapSpacing
+    Container foo = tester.firstWidget(find.byType(Container));
+    expect(foo.margin, const EdgeInsets.only(bottom: 10.0));
   });
 
   testWidgets('FormBuilderCheckboxGroup -- didChange',

--- a/test/form_builder_radio_group_test.dart
+++ b/test/form_builder_radio_group_test.dart
@@ -28,53 +28,6 @@ void main() {
     expect(formValue(widgetName), equals(3));
   });
 
-  testWidgets('FormBuilderRadioGroup -- decoration control leading',
-      (WidgetTester tester) async {
-    const widgetName = 'rg1';
-    final testWidget = FormBuilderRadioGroup<int>(
-      name: widgetName,
-      wrapSpacing: 10.0,
-      options: const [
-        FormBuilderFieldOption(key: ValueKey('1'), value: 1),
-        FormBuilderFieldOption(key: ValueKey('2'), value: 2),
-      ],
-      itemDecoration:
-          BoxDecoration(border: Border.all(color: Colors.blueAccent)),
-    );
-    await tester.pumpWidget(buildTestableFieldWidget(testWidget));
-
-    // this is a brittle test knowing how we use container for a border
-    // there is one container for each option
-    expect(find.byType(Container), findsExactly(2));
-    // same as wrapSpacing
-    Container foo = tester.firstWidget(find.byType(Container));
-    expect(foo.padding, const EdgeInsets.only(right: 10.0));
-  });
-
-  testWidgets('FormBuilderRadioGroup -- decoration control following',
-      (WidgetTester tester) async {
-    const widgetName = 'rg1';
-    final testWidget = FormBuilderRadioGroup<int>(
-      name: widgetName,
-      controlAffinity: ControlAffinity.trailing,
-      wrapSpacing: 10.0,
-      options: const [
-        FormBuilderFieldOption(key: ValueKey('1'), value: 1),
-        FormBuilderFieldOption(key: ValueKey('2'), value: 2),
-      ],
-      itemDecoration:
-          BoxDecoration(border: Border.all(color: Colors.blueAccent)),
-    );
-    await tester.pumpWidget(buildTestableFieldWidget(testWidget));
-
-    // this is a brittle test knowing how we use container for a border
-    // there is one container for each option
-    expect(find.byType(Container), findsExactly(2));
-    // same as wrapSpacing
-    Container foo = tester.firstWidget(find.byType(Container));
-    expect(foo.padding, const EdgeInsets.only(left: 10.0));
-  });
-
   testWidgets('FormBuilderRadioGroup -- decoration horizontal',
       (WidgetTester tester) async {
     const widgetName = 'rg1';

--- a/test/form_builder_radio_group_test.dart
+++ b/test/form_builder_radio_group_test.dart
@@ -28,15 +28,15 @@ void main() {
     expect(formValue(widgetName), equals(3));
   });
 
-  testWidgets('FormBuilderRadioGroup -- decoration',
+  testWidgets('FormBuilderRadioGroup -- decoration control leading',
       (WidgetTester tester) async {
     const widgetName = 'rg1';
     final testWidget = FormBuilderRadioGroup<int>(
       name: widgetName,
+      wrapSpacing: 10.0,
       options: const [
         FormBuilderFieldOption(key: ValueKey('1'), value: 1),
         FormBuilderFieldOption(key: ValueKey('2'), value: 2),
-        FormBuilderFieldOption(key: ValueKey('3'), value: 3),
       ],
       itemDecoration:
           BoxDecoration(border: Border.all(color: Colors.blueAccent)),
@@ -45,6 +45,81 @@ void main() {
 
     // this is a brittle test knowing how we use container for a border
     // there is one container for each option
-    expect(find.byType(Container), findsExactly(3));
+    expect(find.byType(Container), findsExactly(2));
+    // same as wrapSpacing
+    Container foo = tester.firstWidget(find.byType(Container));
+    expect(foo.padding, const EdgeInsets.only(right: 10.0));
+  });
+
+  testWidgets('FormBuilderRadioGroup -- decoration control following',
+      (WidgetTester tester) async {
+    const widgetName = 'rg1';
+    final testWidget = FormBuilderRadioGroup<int>(
+      name: widgetName,
+      controlAffinity: ControlAffinity.trailing,
+      wrapSpacing: 10.0,
+      options: const [
+        FormBuilderFieldOption(key: ValueKey('1'), value: 1),
+        FormBuilderFieldOption(key: ValueKey('2'), value: 2),
+      ],
+      itemDecoration:
+          BoxDecoration(border: Border.all(color: Colors.blueAccent)),
+    );
+    await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+    // this is a brittle test knowing how we use container for a border
+    // there is one container for each option
+    expect(find.byType(Container), findsExactly(2));
+    // same as wrapSpacing
+    Container foo = tester.firstWidget(find.byType(Container));
+    expect(foo.padding, const EdgeInsets.only(left: 10.0));
+  });
+
+  testWidgets('FormBuilderRadioGroup -- decoration horizontal',
+      (WidgetTester tester) async {
+    const widgetName = 'rg1';
+    final testWidget = FormBuilderRadioGroup<int>(
+      name: widgetName,
+      orientation: OptionsOrientation.horizontal,
+      wrapSpacing: 10.0,
+      options: const [
+        FormBuilderFieldOption(key: ValueKey('1'), value: 1),
+        FormBuilderFieldOption(key: ValueKey('2'), value: 2),
+      ],
+      itemDecoration:
+          BoxDecoration(border: Border.all(color: Colors.blueAccent)),
+    );
+    await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+    // this is a brittle test knowing how we use container for a border
+    // there is one container for each option
+    expect(find.byType(Container), findsExactly(2));
+    // same as wrapSpacing
+    Container foo = tester.firstWidget(find.byType(Container));
+    expect(foo.margin, const EdgeInsets.only(right: 10.0));
+  });
+
+  testWidgets('FormBuilderRadioGroup -- decoration vertical',
+      (WidgetTester tester) async {
+    const widgetName = 'rg1';
+    final testWidget = FormBuilderRadioGroup<int>(
+      name: widgetName,
+      orientation: OptionsOrientation.vertical,
+      wrapSpacing: 10.0,
+      options: const [
+        FormBuilderFieldOption(key: ValueKey('1'), value: 1),
+        FormBuilderFieldOption(key: ValueKey('2'), value: 2),
+      ],
+      itemDecoration:
+          BoxDecoration(border: Border.all(color: Colors.blueAccent)),
+    );
+    await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+    // this is a brittle test knowing how we use container for a border
+    // there is one container for each option
+    expect(find.byType(Container), findsExactly(2));
+    // same as wrapSpacing
+    Container foo = tester.firstWidget(find.byType(Container));
+    expect(foo.margin, const EdgeInsets.only(bottom: 10.0));
   });
 }

--- a/test/form_builder_radio_group_test.dart
+++ b/test/form_builder_radio_group_test.dart
@@ -27,4 +27,24 @@ void main() {
     expect(formSave(), isTrue);
     expect(formValue(widgetName), equals(3));
   });
+
+  testWidgets('FormBuilderRadioGroup -- decoration',
+      (WidgetTester tester) async {
+    const widgetName = 'rg1';
+    final testWidget = FormBuilderRadioGroup<int>(
+      name: widgetName,
+      options: const [
+        FormBuilderFieldOption(key: ValueKey('1'), value: 1),
+        FormBuilderFieldOption(key: ValueKey('2'), value: 2),
+        FormBuilderFieldOption(key: ValueKey('3'), value: 3),
+      ],
+      itemDecoration:
+          BoxDecoration(border: Border.all(color: Colors.blueAccent)),
+    );
+    await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+    // this is a brittle test knowing how we use container for a border
+    // there is one container for each option
+    expect(find.byType(Container), findsExactly(3));
+  });
 }


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #1343

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->
Connected to #???

## Solution description

This change adds a `BoxDecoration`  property called `itemDecorator` to FormBuilderCheckboxGroup and FormBiulderRadioGroup that is passed to every item they build.  This lets you add borders to checkbox items and radio buttons. 

1. Inter-control spacing is still set via the `wrapSpacing` property.  
2. Intra-control margins on the side opposite the control (radio or checkbox) need to be set if the label is text only and a box is applied.  There is no parameter for this.  I looked at using `wrapSpacing` but that was a hack.  The work around is to add trailing spaces to the label text :-(

## Screenshots or Videos

This screenshot shows the changes to the example program.  I deliberately showed the default behavior for text when a border is applied.

![flutter-form-builder-inputDecoration-8](https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/assets/1217160/b756dfac-2c71-44df-bdfd-ebe7026f5e53)

![flutter-form-builder-inputDecoration-7](https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/assets/1217160/9bdb3748-c786-43da-8c7f-f1d589669a5c)

## To Do

- [X] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [X] Check the original issue to confirm it is fully satisfied
- [X] Add solution description to help guide reviewers
- [X] Add unit test to verify new or fixed behaviour
- [X] If apply, add documentation to code properties and package readme
