### PR TITLE
Pass parameter keyboardType to material showDatePicker

### DIFF
--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -343,6 +343,7 @@ class _FormBuilderDateTimePickerState extends FormBuilderFieldDecorationState<
       routeSettings: widget.routeSettings,
       currentDate: widget.currentDate,
       anchorPoint: widget.anchorPoint,
+      keyboardType: widget.keyboardType,
     );
   }
 

--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -68,7 +68,7 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
   /// `null` if [format] fails to parse the text.
   final ValueChanged<DateTime?>? onFieldSubmitted;
   final TextEditingController? controller;
-  final TextInputType keyboardType;
+  final TextInputType? keyboardType;
   final TextStyle? style;
   final TextAlign textAlign;
   final TextAlignVertical? textAlignVertical;
@@ -147,7 +147,7 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
     this.enableInteractiveSelection = true,
     this.resetIcon = const Icon(Icons.close),
     this.initialTime = const TimeOfDay(hour: 12, minute: 0),
-    this.keyboardType = TextInputType.text,
+    this.keyboardType,
     this.textAlign = TextAlign.start,
     this.autofocus = false,
     this.obscureText = false,

--- a/test/src/fields/form_builder_date_time_picker_test.dart
+++ b/test/src/fields/form_builder_date_time_picker_test.dart
@@ -40,6 +40,28 @@ void main() {
       expect(formValue<DateTime>(widgetName),
           DateTime(dateNow.year, dateNow.month, testDay, 12));
     });
+    testWidgets('input keyboard type', (WidgetTester tester) async {
+      const widgetName = 'fdtp3';
+      final widgetKey = UniqueKey();
+      const keyboardType = TextInputType.datetime;
+
+      final testWidget = FormBuilderDateTimePicker(
+        key: widgetKey,
+        name: widgetName,
+        keyboardType: keyboardType,
+        inputType: InputType.date,
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+      await tester.tap(find.byKey(widgetKey));
+      await tester.pumpAndSettle();
+
+      // change to input edition
+      await tester.tap(find.byIcon(Icons.edit_outlined));
+      await tester.pumpAndSettle();
+
+      final textField = tester.widget<TextField>(find.byType(TextField).first);
+      expect(textField.keyboardType, equals(keyboardType));
+    });
     group('initial value -', () {
       testWidgets('to FormBuilder', (WidgetTester tester) async {
         const widgetName = 'fdtp2';


### PR DESCRIPTION
Hello!

We got some issues with users trying to edit the date in the material datepicker with Samsung Keyboard. \
Sadly is a well known flutter issue,  \
https://github.com/flutter/flutter/issues/62401 

## Solution description
The material datepicker allow to choose the keyboardType. Although it's not the best user experience, we want to set the keyboardType to text. The FormBuilderDateTimePicker receives the parameter put don't pass it for the material showDatePícker.

## Screenshots or Videos

![image](https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/assets/54868778/a433d6e3-24de-4806-96fc-f267d93a1377)

#1351 
I opened the above issue to discuss the default value of FormBuilderDateTimePicker

## To Do

- [X] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [X] Check the original issue to confirm it is fully satisfied
- [X] Add solution description to help guide reviewers
- [X] Add unit test to verify new or fixed behaviour
- [X] If apply, add documentation to code properties and package readme
