### PR TITLE
docs: Note about form_builder_validators being a separate package

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,10 @@ See [pub.dev example tab](https://pub.dev/packages/flutter_form_builder/example)
 ### Specific uses
 
 #### Validate and get values
-  
+
+Note: Validators are in a separate package
+([form_builder_validators](https://pub.dev/packages/form_builder_validators)).
+
   ```dart
   final _formKey = GlobalKey<FormBuilderState>();
 


### PR DESCRIPTION
Fixes #1280

## Connection with issue(s)

Close #1280

## Solution description

The readme doesn't currently mention the fact that validators must be installed separately from the main package.

## To Do

- [X] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [X] Check the original issue to confirm it is fully satisfied
- [X] Add solution description to help guide reviewers
- [X] Add unit test to verify new or fixed behaviour
- [X] If apply, add documentation to code properties and package readme
