### PR TITLE
Add OverflowBar layout for radios and checkboxes

### DIFF
--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -2,7 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_form_builder/src/extensions/autovalidatemode_extension.dart';
 
-enum OptionsOrientation { horizontal, vertical, wrap }
+enum OptionsOrientation { horizontal, vertical, wrap, auto }
 
 enum ControlAffinity { leading, trailing }
 

--- a/lib/src/widgets/grouped_checkbox.dart
+++ b/lib/src/widgets/grouped_checkbox.dart
@@ -224,7 +224,12 @@ class GroupedCheckbox<T> extends StatelessWidget {
       widgetList.add(buildItem(i));
     }
     Widget finalWidget;
-    if (orientation == OptionsOrientation.vertical) {
+    if (orientation == OptionsOrientation.auto) {
+      finalWidget = OverflowBar(
+        alignment: MainAxisAlignment.spaceEvenly,
+        children: widgetList,
+      );
+    } else if (orientation == OptionsOrientation.vertical) {
       finalWidget = SingleChildScrollView(
         scrollDirection: Axis.vertical,
         child: Column(

--- a/lib/src/widgets/grouped_radio.dart
+++ b/lib/src/widgets/grouped_radio.dart
@@ -218,6 +218,11 @@ class _GroupedRadioState<T> extends State<GroupedRadio<T?>> {
     }
 
     switch (widget.orientation) {
+      case OptionsOrientation.auto:
+        return OverflowBar(
+          alignment: MainAxisAlignment.spaceEvenly,
+          children: widgetList,
+        );
       case OptionsOrientation.vertical:
         return SingleChildScrollView(
           scrollDirection: Axis.vertical,


### PR DESCRIPTION
Hi,

I'm sorry I did not discuss the change prior to pushing a PR but that's a necessary request as we're locked building our UI without the requested change.

Unfortunately, my time on this is very limited so feel free to edit and enhance the PR as I did not add tests for it. However, the change is completely opt-in and has no chance of breaking existing code

## Solution description

This allows to use `OptionsOrientation.auto` with Radio and Checbkoxes for an easy responsive layout.

## Screenshots or Videos

When content is smaller than container's width
<img width="466" alt="Capture d’écran 2024-04-29 à 10 10 19" src="https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/assets/2227736/d8ee7440-51ef-40e3-ac32-7d577cb8c532">

When content is larger than container's width
<img width="479" alt="Capture d’écran 2024-04-29 à 10 10 23" src="https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/assets/2227736/4d0e19d3-89de-4d9c-87f6-cdff9928ef09">

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme
