### PR TITLE
feat(FormBuilderTextField): #1334 set `enableSuggestions` default to `true`

### DIFF
--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -340,7 +340,7 @@ class FormBuilderTextField extends FormBuilderFieldDecoration<String> {
     this.showCursor,
     this.onTap,
     this.onTapOutside,
-    this.enableSuggestions = false,
+    this.enableSuggestions = true,
     this.textAlignVertical,
     this.dragStartBehavior = DragStartBehavior.start,
     this.scrollController,


### PR DESCRIPTION
## Solution description

This sets the default of `enableSuggestions` on `FormBuilderTextField` to `true`. This is also the default of the normal `TextField` widget. (see https://api.flutter.dev/flutter/material/TextField/enableSuggestions.html)

Close #1334
Close #1369
Close #1375

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [ ] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme
