### PR TITLE
fix: #1350 valueTransformer transform values to null

### DIFF
--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -170,14 +170,24 @@ class FormBuilderState extends State<FormBuilder> {
   /// Get all fields of form.
   FormBuilderFields get fields => _fields;
 
-  Map<String, dynamic> get instantValue =>
-      Map<String, dynamic>.unmodifiable(_instantValue.map((key, value) =>
-          MapEntry(key, _transformers[key]?.call(value) ?? value)));
+  Map<String, dynamic> get instantValue => Map<String, dynamic>.unmodifiable(
+        _instantValue.map(
+          (key, value) => MapEntry(
+            key,
+            _transformers[key] == null ? value : _transformers[key]!(value),
+          ),
+        ),
+      );
 
   /// Returns the saved value only
-  Map<String, dynamic> get value =>
-      Map<String, dynamic>.unmodifiable(_savedValue.map((key, value) =>
-          MapEntry(key, _transformers[key]?.call(value) ?? value)));
+  Map<String, dynamic> get value => Map<String, dynamic>.unmodifiable(
+        _savedValue.map(
+          (key, value) => MapEntry(
+            key,
+            _transformers[key] == null ? value : _transformers[key]!(value),
+          ),
+        ),
+      );
 
   dynamic transformValue<T>(String name, T? v) {
     final t = _transformers[name];

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -88,7 +88,7 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
       (_formBuilderState?.initialValue ??
           const <String, dynamic>{})[widget.name] as T?;
 
-  dynamic get transformedValue => widget.valueTransformer?.call(value) ?? value;
+  dynamic get transformedValue => widget.valueTransformer == null ? value : widget.valueTransformer!(value);
 
   @override
   String? get errorText => super.errorText ?? _customErrorText;

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -88,7 +88,8 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
       (_formBuilderState?.initialValue ??
           const <String, dynamic>{})[widget.name] as T?;
 
-  dynamic get transformedValue => widget.valueTransformer == null ? value : widget.valueTransformer!(value);
+  dynamic get transformedValue =>
+      widget.valueTransformer == null ? value : widget.valueTransformer!(value);
 
   @override
   String? get errorText => super.errorText ?? _customErrorText;

--- a/test/src/form_builder_test.dart
+++ b/test/src/form_builder_test.dart
@@ -39,10 +39,14 @@ void main() {
           ),
         );
 
+        // Write an input resulting in a null value after transformation
+        formFieldDidChange(testWidgetName, 'a');
+        expect(formInstantValue(testWidgetName), isNull);
+
         // Write an input and test the transformer
         formFieldDidChange(testWidgetName, '1');
-        expect(int, formInstantValue(testWidgetName).runtimeType);
-        expect(1, formInstantValue(testWidgetName));
+        expect(formInstantValue(testWidgetName).runtimeType, int);
+        expect(formInstantValue(testWidgetName), 1);
 
         // Remove the dynamic field from the widget tree
         final _DynamicFormFieldsState dynamicFieldState =
@@ -54,8 +58,8 @@ void main() {
 
         // With the field unregistered, the form does not have its transformer
         // but it still has its value, now recovered as type String
-        expect(String, formInstantValue(testWidgetName).runtimeType);
-        expect('1', formInstantValue(testWidgetName));
+        expect(formInstantValue(testWidgetName).runtimeType, String);
+        expect(formInstantValue(testWidgetName), '1');
 
         // Show and recreate the field's state
         dynamicFieldState.show = true;
@@ -63,8 +67,8 @@ void main() {
 
         // The transformer is registered again and with the internal value that
         // was kept, it's expected an int of value 1
-        expect(int, formInstantValue(testWidgetName).runtimeType);
-        expect(1, formInstantValue(testWidgetName));
+        expect(formInstantValue(testWidgetName).runtimeType, int);
+        expect(formInstantValue(testWidgetName), 1);
       },
     );
 
@@ -102,8 +106,8 @@ void main() {
 
         // With the field unregistered, the form does not have its transformer,
         // and since the value was cleared, neither its value
-        expect(Null, formInstantValue(testWidgetName).runtimeType);
-        expect(null, formInstantValue(testWidgetName));
+        expect(formInstantValue(testWidgetName).runtimeType, Null);
+        expect(formInstantValue(testWidgetName), isNull);
 
         // Show and recreate the field's state
         dynamicFieldState.show = true;
@@ -112,8 +116,8 @@ void main() {
         // A new input is needed to get another value
         formFieldDidChange(testWidgetName, '2');
         await tester.pump();
-        expect(int, formInstantValue(testWidgetName).runtimeType);
-        expect(2, formInstantValue(testWidgetName));
+        expect(formInstantValue(testWidgetName).runtimeType, int);
+        expect(formInstantValue(testWidgetName), 2);
       },
     );
   });


### PR DESCRIPTION
Fix for issue 1350 with some changes to tests. This fix makes it so that valueTransformer can transform values to null.

## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #1350 

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->
Connected to #???

## Solution description

Changes to implementation of value transformer so that it is still used if value is transformed to null.
I also found that the tests also had flipped values in the expect functions (actual and matcher was wrong way around)

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [ x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [ x] Check the original issue to confirm it is fully satisfied
- [ x] Add solution description to help guide reviewers
- [ x] Add unit test to verify new or fixed behaviour
- [ x] If apply, add documentation to code properties and package readme
