### PR TITLE
fix: #1398 add hint to FormBuilderDropdown

### DIFF
--- a/lib/src/fields/form_builder_dropdown.dart
+++ b/lib/src/fields/form_builder_dropdown.dart
@@ -253,6 +253,7 @@ class FormBuilderDropdown<T> extends FormBuilderFieldDecoration<T> {
     this.enableFeedback,
     this.borderRadius,
     this.alignment = AlignmentDirectional.centerStart,
+    Widget? hint,
   }) : super(
           builder: (FormFieldState<T?> field) {
             final state = field as _FormBuilderDropdownState<T>;
@@ -289,6 +290,7 @@ class FormBuilderDropdown<T> extends FormBuilderFieldDecoration<T> {
               borderRadius: borderRadius,
               enableFeedback: enableFeedback,
               alignment: alignment,
+              hint: hint,
             );
           },
         );

--- a/lib/src/fields/form_builder_dropdown.dart
+++ b/lib/src/fields/form_builder_dropdown.dart
@@ -218,6 +218,15 @@ class FormBuilderDropdown<T> extends FormBuilderFieldDecoration<T> {
   /// are defined by the corresponding properties of the [borderRadius].
   final BorderRadius? borderRadius;
 
+  /// A placeholder widget that is displayed by the dropdown button.
+  ///
+  /// If [value] is null and the dropdown is enabled ([items] and [onChanged] are non-null),
+  /// this widget is displayed as a placeholder for the dropdown button's value.
+  ///
+  /// If [value] is null and the dropdown is disabled and [disabledHint] is null,
+  /// this widget is used as the placeholder.
+  final Widget? hint;
+
   /// Creates field for Dropdown button
   FormBuilderDropdown({
     super.key,
@@ -253,7 +262,7 @@ class FormBuilderDropdown<T> extends FormBuilderFieldDecoration<T> {
     this.enableFeedback,
     this.borderRadius,
     this.alignment = AlignmentDirectional.centerStart,
-    Widget? hint,
+    this.hint,
   }) : super(
           builder: (FormFieldState<T?> field) {
             final state = field as _FormBuilderDropdownState<T>;


### PR DESCRIPTION
## Connection with issue(s)

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->
Connected to #1398
Related to this Flutter issue https://github.com/flutter/flutter/issues/111958 

## Solution description
- Add a hint widget to FormBuilderDropdown

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [] Check the original issue to confirm it is fully satisfied
- [ ] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme
