### PR TITLE
Add "barrierDismissible" to DateTime picker

### DIFF
--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -125,6 +125,7 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
   final SelectableDayPredicate? selectableDayPredicate;
   final Offset? anchorPoint;
   final EntryModeChangeCallback? onEntryModeChanged;
+  final bool barrierDismissible;
 
   /// Creates field for `Date`, `Time` and `DateTime` input
   FormBuilderDateTimePicker({
@@ -195,6 +196,7 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
     this.selectableDayPredicate,
     this.anchorPoint,
     this.onEntryModeChanged,
+    this.barrierDismissible = true,
   }) : super(
           builder: (FormFieldState<DateTime?> field) {
             final state = field as _FormBuilderDateTimePickerState;
@@ -342,6 +344,7 @@ class _FormBuilderDateTimePickerState extends FormBuilderFieldDecorationState<
       currentDate: widget.currentDate,
       anchorPoint: widget.anchorPoint,
       keyboardType: widget.keyboardType,
+      barrierDismissible: widget.barrierDismissible,
     );
   }
 
@@ -375,6 +378,7 @@ class _FormBuilderDateTimePickerState extends FormBuilderFieldDecorationState<
       anchorPoint: widget.anchorPoint,
       errorInvalidText: widget.errorInvalidText,
       onEntryModeChanged: widget.onEntryModeChanged,
+      barrierDismissible: widget.barrierDismissible,
     );
     return timePickerResult ??
         (currentValue != null ? TimeOfDay.fromDateTime(currentValue) : null);


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #???

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->
Connected to #???

## Solution description
This will add the missing "barrierDismissible" field to both date and time picker dialogs. Will be 'true' by default to keep the previous behavior.

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
