### PR TITLE
fix: #1434 Replace dropdown

### DIFF
--- a/lib/src/fields/form_builder_dropdown.dart
+++ b/lib/src/fields/form_builder_dropdown.dart
@@ -163,6 +163,12 @@ class FormBuilderDropdown<T> extends FormBuilderFieldDecoration<T> {
   /// [kMinInteractiveDimension].
   final double? itemHeight;
 
+  /// The width of the menu.
+  ///
+  /// If it is not provided, the width of the menu is the width of the
+  /// dropdown button.
+  final double? menuWidth;
+
   /// The color for the button's [Material] when it has the input focus.
   final Color? focusColor;
 
@@ -174,6 +180,17 @@ class FormBuilderDropdown<T> extends FormBuilderFieldDecoration<T> {
   /// If it is not provided, the theme's [ThemeData.canvasColor] will be used
   /// instead.
   final Color? dropdownColor;
+
+  /// Padding around the visible portion of the dropdown widget.
+  ///
+  /// As the padding increases, the size of the [DropdownButton] will also
+  /// increase. The padding is included in the clickable area of the dropdown
+  /// widget, so this can make the widget easier to click.
+  ///
+  /// Padding can be useful when used with a custom border. The clickable
+  /// area will stay flush with the border, as opposed to an external [Padding]
+  /// widget which will leave a non-clickable gap.
+  final EdgeInsetsGeometry? padding;
 
   /// The maximum height of the menu.
   ///
@@ -227,6 +244,11 @@ class FormBuilderDropdown<T> extends FormBuilderFieldDecoration<T> {
   /// this widget is used as the placeholder.
   final Widget? hint;
 
+  /// The widget to use for drawing the drop-down button's underline.
+  ///
+  /// Defaults to SizedBox.shrink().
+  final Widget? underline;
+
   /// Creates field for Dropdown button
   FormBuilderDropdown({
     super.key,
@@ -263,43 +285,54 @@ class FormBuilderDropdown<T> extends FormBuilderFieldDecoration<T> {
     this.borderRadius,
     this.alignment = AlignmentDirectional.centerStart,
     this.hint,
+    this.underline = const SizedBox.shrink(),
+    this.padding,
+    this.menuWidth,
   }) : super(
           builder: (FormFieldState<T?> field) {
             final state = field as _FormBuilderDropdownState<T>;
 
             final hasValue = items.map((e) => e.value).contains(field.value);
-            return DropdownButtonFormField<T>(
-              isExpanded: isExpanded,
+            return InputDecorator(
               decoration: state.decoration,
-              items: items,
-              value: hasValue ? field.value : null,
-              style: style,
-              isDense: isDense,
-              disabledHint: hasValue
-                  ? items
-                      .firstWhere(
-                          (dropDownItem) => dropDownItem.value == field.value)
-                      .child
-                  : disabledHint,
-              elevation: elevation,
-              iconSize: iconSize,
-              icon: icon,
-              iconDisabledColor: iconDisabledColor,
-              iconEnabledColor: iconEnabledColor,
-              onChanged:
-                  state.enabled ? (T? value) => state.didChange(value) : null,
-              onTap: onTap,
-              focusNode: state.effectiveFocusNode,
-              autofocus: autofocus,
-              dropdownColor: dropdownColor,
-              focusColor: focusColor,
-              itemHeight: itemHeight,
-              selectedItemBuilder: selectedItemBuilder,
-              menuMaxHeight: menuMaxHeight,
-              borderRadius: borderRadius,
-              enableFeedback: enableFeedback,
-              alignment: alignment,
-              hint: hint,
+              child: DropdownButton<T>(
+                menuWidth: menuWidth,
+                padding: padding,
+                underline: underline,
+                isExpanded: isExpanded,
+                items: items,
+                value: hasValue ? field.value : null,
+                style: style,
+                isDense: isDense,
+                disabledHint: hasValue
+                    ? items
+                        .firstWhere(
+                            (dropDownItem) => dropDownItem.value == field.value)
+                        .child
+                    : disabledHint,
+                elevation: elevation,
+                iconSize: iconSize,
+                icon: icon,
+                iconDisabledColor: iconDisabledColor,
+                iconEnabledColor: iconEnabledColor,
+                onChanged: state.enabled
+                    ? (T? value) {
+                        field.didChange(value);
+                      }
+                    : null,
+                onTap: onTap,
+                focusNode: state.effectiveFocusNode,
+                autofocus: autofocus,
+                dropdownColor: dropdownColor,
+                focusColor: focusColor,
+                itemHeight: itemHeight,
+                selectedItemBuilder: selectedItemBuilder,
+                menuMaxHeight: menuMaxHeight,
+                borderRadius: borderRadius,
+                enableFeedback: enableFeedback,
+                alignment: alignment,
+                hint: hint,
+              ),
             );
           },
         );

--- a/test/src/fields/form_builder_dropdown_test.dart
+++ b/test/src/fields/form_builder_dropdown_test.dart
@@ -225,6 +225,47 @@ void main() {
       expect(formValue(widgetName), equals(2));
     });
   });
+  testWidgets('Should reset to null when call reset', (tester) async {
+    const widgetName = 'dropdown_field';
+
+    // Define the initial and updated items for the dropdown
+    const List<DropdownMenuItem<int>> initialItems = [
+      DropdownMenuItem(value: 1, child: Text('Option 1')),
+      DropdownMenuItem(value: 2, child: Text('Option 2')),
+    ];
+
+    final testWidget =
+        FormBuilderDropdown(name: widgetName, items: initialItems);
+    await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+    formKey.currentState?.patchValue({widgetName: 1});
+    await tester.pumpAndSettle();
+    formKey.currentState?.reset();
+
+    expect(formKey.currentState?.instantValue, {widgetName: null});
+  });
+  testWidgets('Should reset to initial when call reset', (tester) async {
+    const widgetName = 'dropdown_field';
+    const initialValue = {widgetName: 1};
+
+    // Define the initial and updated items for the dropdown
+    const List<DropdownMenuItem<int>> initialItems = [
+      DropdownMenuItem(value: 1, child: Text('Option 1')),
+      DropdownMenuItem(value: 2, child: Text('Option 2')),
+    ];
+    final testWidget =
+        FormBuilderDropdown(name: widgetName, items: initialItems);
+    await tester.pumpWidget(buildTestableFieldWidget(
+      testWidget,
+      initialValue: initialValue,
+    ));
+
+    formKey.currentState?.patchValue({widgetName: 2});
+    await tester.pumpAndSettle();
+    formKey.currentState?.reset();
+
+    expect(formKey.currentState?.instantValue, equals(initialValue));
+  });
 }
 
 class MyTestWidget<T> extends StatefulWidget {


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #1402
Close #1371

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->
Connected to #???

## Solution description

Replace a Dropdown that inclue a FormState to other with only the design logic

## Screenshots or Videos

[Screencast from 2024-12-26 19-10-16.webm](https://github.com/user-attachments/assets/814562bb-24e8-46e8-8349-b43626760dbc)

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [X] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [X] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [X] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
