### PR TITLE
Feat: Add patchError function to FormBuilder

### DIFF
--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -110,16 +110,14 @@ class FormBuilder extends StatefulWidget {
     this.canPop,
   });
 
-  static FormBuilderState? of(BuildContext context) =>
-      context.findAncestorStateOfType<FormBuilderState>();
+  static FormBuilderState? of(BuildContext context) => context.findAncestorStateOfType<FormBuilderState>();
 
   @override
   FormBuilderState createState() => FormBuilderState();
 }
 
 /// A type alias for a map of form fields.
-typedef FormBuilderFields =
-    Map<String, FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>>;
+typedef FormBuilderFields = Map<String, FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>>;
 
 class FormBuilderState extends State<FormBuilder> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
@@ -153,9 +151,7 @@ class FormBuilderState extends State<FormBuilder> {
 
   /// Get a map of errors
   Map<String, String> get errors => {
-    for (var element in fields.entries.where(
-      (element) => element.value.hasError,
-    ))
+    for (var element in fields.entries.where((element) => element.value.hasError))
       element.key.toString(): element.value.errorText ?? '',
   };
 
@@ -167,22 +163,12 @@ class FormBuilderState extends State<FormBuilder> {
 
   /// Get all fields values of form.
   Map<String, dynamic> get instantValue => Map<String, dynamic>.unmodifiable(
-    _instantValue.map(
-      (key, value) => MapEntry(
-        key,
-        _transformers[key] == null ? value : _transformers[key]!(value),
-      ),
-    ),
+    _instantValue.map((key, value) => MapEntry(key, _transformers[key] == null ? value : _transformers[key]!(value))),
   );
 
   /// Returns the saved value only
   Map<String, dynamic> get value => Map<String, dynamic>.unmodifiable(
-    _savedValue.map(
-      (key, value) => MapEntry(
-        key,
-        _transformers[key] == null ? value : _transformers[key]!(value),
-      ),
-    ),
+    _savedValue.map((key, value) => MapEntry(key, _transformers[key] == null ? value : _transformers[key]!(value))),
   );
 
   dynamic transformValue<T>(String name, T? v) {
@@ -195,8 +181,7 @@ class FormBuilderState extends State<FormBuilder> {
   }
 
   T? getRawValue<T>(String name, {bool fromSaved = false}) {
-    return (fromSaved ? _savedValue[name] : _instantValue[name]) ??
-        initialValue[name];
+    return (fromSaved ? _savedValue[name] : _instantValue[name]) ?? initialValue[name];
   }
 
   /// Get a field value by name
@@ -290,15 +275,11 @@ class FormBuilderState extends State<FormBuilder> {
   /// the form will auto scroll to show this invalid field.
   /// In this case, the automatic scroll happens because is a behavior inside the framework,
   /// not because [autoScrollWhenFocusOnInvalid] is `true`.
-  bool validate({
-    bool focusOnInvalid = true,
-    bool autoScrollWhenFocusOnInvalid = false,
-  }) {
+  bool validate({bool focusOnInvalid = true, bool autoScrollWhenFocusOnInvalid = false}) {
     _focusOnInvalid = focusOnInvalid;
     final hasError = !_formKey.currentState!.validate();
     if (hasError) {
-      final wrongFields =
-          fields.values.where((element) => element.hasError).toList();
+      final wrongFields = fields.values.where((element) => element.hasError).toList();
       if (wrongFields.isNotEmpty) {
         if (focusOnInvalid) {
           wrongFields.first.focus();
@@ -323,15 +304,9 @@ class FormBuilderState extends State<FormBuilder> {
   /// the form will auto scroll to show this invalid field.
   /// In this case, the automatic scroll happens because is a behavior inside the framework,
   /// not because [autoScrollWhenFocusOnInvalid] is `true`.
-  bool saveAndValidate({
-    bool focusOnInvalid = true,
-    bool autoScrollWhenFocusOnInvalid = false,
-  }) {
+  bool saveAndValidate({bool focusOnInvalid = true, bool autoScrollWhenFocusOnInvalid = false}) {
     save();
-    return validate(
-      focusOnInvalid: focusOnInvalid,
-      autoScrollWhenFocusOnInvalid: autoScrollWhenFocusOnInvalid,
-    );
+    return validate(focusOnInvalid: focusOnInvalid, autoScrollWhenFocusOnInvalid: autoScrollWhenFocusOnInvalid);
   }
 
   /// Reset form to `initialValue` set on FormBuilder or on each field.
@@ -346,6 +321,14 @@ class FormBuilderState extends State<FormBuilder> {
   void patchValue(Map<String, dynamic> val) {
     val.forEach((key, dynamic value) {
       _fields[key]?.didChange(value);
+    });
+  }
+
+  /// Update fields errors of form.
+  /// Useful when need update errors at once, after got errors from server.
+  void patchError(Map<String, String> errors) {
+    errors.forEach((key, value) {
+      _fields[key]?.invalidate(value);
     });
   }
 
@@ -369,19 +352,13 @@ class FormBuilderState extends State<FormBuilder> {
       onPopInvokedWithResult: widget.onPopInvokedWithResult,
       canPop: widget.canPop,
       // `onChanged` is called during setInternalFieldValue else will be called early
-      child: _FormBuilderScope(
-        formState: this,
-        child: FocusTraversalGroup(child: widget.child),
-      ),
+      child: _FormBuilderScope(formState: this, child: FocusTraversalGroup(child: widget.child)),
     );
   }
 }
 
 class _FormBuilderScope extends InheritedWidget {
-  const _FormBuilderScope({
-    required super.child,
-    required FormBuilderState formState,
-  }) : _formState = formState;
+  const _FormBuilderScope({required super.child, required FormBuilderState formState}) : _formState = formState;
 
   final FormBuilderState _formState;
 
@@ -389,6 +366,5 @@ class _FormBuilderScope extends InheritedWidget {
   FormBuilder get form => _formState.widget;
 
   @override
-  bool updateShouldNotify(_FormBuilderScope oldWidget) =>
-      oldWidget._formState != _formState;
+  bool updateShouldNotify(_FormBuilderScope oldWidget) => oldWidget._formState != _formState;
 }

--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -110,14 +110,16 @@ class FormBuilder extends StatefulWidget {
     this.canPop,
   });
 
-  static FormBuilderState? of(BuildContext context) => context.findAncestorStateOfType<FormBuilderState>();
+  static FormBuilderState? of(BuildContext context) =>
+      context.findAncestorStateOfType<FormBuilderState>();
 
   @override
   FormBuilderState createState() => FormBuilderState();
 }
 
 /// A type alias for a map of form fields.
-typedef FormBuilderFields = Map<String, FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>>;
+typedef FormBuilderFields =
+    Map<String, FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>>;
 
 class FormBuilderState extends State<FormBuilder> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
@@ -151,7 +153,9 @@ class FormBuilderState extends State<FormBuilder> {
 
   /// Get a map of errors
   Map<String, String> get errors => {
-    for (var element in fields.entries.where((element) => element.value.hasError))
+    for (var element in fields.entries.where(
+      (element) => element.value.hasError,
+    ))
       element.key.toString(): element.value.errorText ?? '',
   };
 
@@ -163,12 +167,22 @@ class FormBuilderState extends State<FormBuilder> {
 
   /// Get all fields values of form.
   Map<String, dynamic> get instantValue => Map<String, dynamic>.unmodifiable(
-    _instantValue.map((key, value) => MapEntry(key, _transformers[key] == null ? value : _transformers[key]!(value))),
+    _instantValue.map(
+      (key, value) => MapEntry(
+        key,
+        _transformers[key] == null ? value : _transformers[key]!(value),
+      ),
+    ),
   );
 
   /// Returns the saved value only
   Map<String, dynamic> get value => Map<String, dynamic>.unmodifiable(
-    _savedValue.map((key, value) => MapEntry(key, _transformers[key] == null ? value : _transformers[key]!(value))),
+    _savedValue.map(
+      (key, value) => MapEntry(
+        key,
+        _transformers[key] == null ? value : _transformers[key]!(value),
+      ),
+    ),
   );
 
   dynamic transformValue<T>(String name, T? v) {
@@ -181,7 +195,8 @@ class FormBuilderState extends State<FormBuilder> {
   }
 
   T? getRawValue<T>(String name, {bool fromSaved = false}) {
-    return (fromSaved ? _savedValue[name] : _instantValue[name]) ?? initialValue[name];
+    return (fromSaved ? _savedValue[name] : _instantValue[name]) ??
+        initialValue[name];
   }
 
   /// Get a field value by name
@@ -275,7 +290,10 @@ class FormBuilderState extends State<FormBuilder> {
   /// the form will auto scroll to show this invalid field.
   /// In this case, the automatic scroll happens because is a behavior inside the framework,
   /// not because [autoScrollWhenFocusOnInvalid] is `true`.
-  bool validate({bool focusOnInvalid = true, bool autoScrollWhenFocusOnInvalid = false}) {
+  bool validate({
+    bool focusOnInvalid = true,
+    bool autoScrollWhenFocusOnInvalid = false,
+  }) {
     _focusOnInvalid = focusOnInvalid;
     final hasError = !_formKey.currentState!.validate();
     if (hasError) {
@@ -299,9 +317,15 @@ class FormBuilderState extends State<FormBuilder> {
   /// the form will auto scroll to show this invalid field.
   /// In this case, the automatic scroll happens because is a behavior inside the framework,
   /// not because [autoScrollWhenFocusOnInvalid] is `true`.
-  bool saveAndValidate({bool focusOnInvalid = true, bool autoScrollWhenFocusOnInvalid = false}) {
+  bool saveAndValidate({
+    bool focusOnInvalid = true,
+    bool autoScrollWhenFocusOnInvalid = false,
+  }) {
     save();
-    return validate(focusOnInvalid: focusOnInvalid, autoScrollWhenFocusOnInvalid: autoScrollWhenFocusOnInvalid);
+    return validate(
+      focusOnInvalid: focusOnInvalid,
+      autoScrollWhenFocusOnInvalid: autoScrollWhenFocusOnInvalid,
+    );
   }
 
   /// Reset form to `initialValue` set on FormBuilder or on each field.
@@ -332,7 +356,11 @@ class FormBuilderState extends State<FormBuilder> {
   /// the form will auto scroll to show this invalid field.
   /// In this case, the automatic scroll happens because is a behavior inside the framework,
   /// not because [autoScrollWhenFocusOnInvalid] is `true`.
-  void patchError(Map<String, String> errors, {bool focusOnInvalid = true, bool autoScrollWhenFocusOnInvalid = false}) {
+  void patchError(
+    Map<String, String> errors, {
+    bool focusOnInvalid = true,
+    bool autoScrollWhenFocusOnInvalid = false,
+  }) {
     errors.forEach((key, value) {
       _fields[key]?.invalidate(value);
     });
@@ -352,8 +380,12 @@ class FormBuilderState extends State<FormBuilder> {
   /// the form will auto scroll to show this invalid field.
   /// In this case, the automatic scroll happens because is a behavior inside the framework,
   /// not because [autoScrollWhenFocusOnInvalid] is `true`.
-  void scrollToFirstInvalidField({bool focusOnInvalid = true, bool autoScrollWhenFocusOnInvalid = false}) {
-    final wrongFields = fields.values.where((element) => element.hasError).toList();
+  void scrollToFirstInvalidField({
+    bool focusOnInvalid = true,
+    bool autoScrollWhenFocusOnInvalid = false,
+  }) {
+    final wrongFields =
+        fields.values.where((element) => element.hasError).toList();
     if (wrongFields.isNotEmpty) {
       if (focusOnInvalid) {
         wrongFields.first.focus();
@@ -384,13 +416,19 @@ class FormBuilderState extends State<FormBuilder> {
       onPopInvokedWithResult: widget.onPopInvokedWithResult,
       canPop: widget.canPop,
       // `onChanged` is called during setInternalFieldValue else will be called early
-      child: _FormBuilderScope(formState: this, child: FocusTraversalGroup(child: widget.child)),
+      child: _FormBuilderScope(
+        formState: this,
+        child: FocusTraversalGroup(child: widget.child),
+      ),
     );
   }
 }
 
 class _FormBuilderScope extends InheritedWidget {
-  const _FormBuilderScope({required super.child, required FormBuilderState formState}) : _formState = formState;
+  const _FormBuilderScope({
+    required super.child,
+    required FormBuilderState formState,
+  }) : _formState = formState;
 
   final FormBuilderState _formState;
 
@@ -398,5 +436,6 @@ class _FormBuilderScope extends InheritedWidget {
   FormBuilder get form => _formState.widget;
 
   @override
-  bool updateShouldNotify(_FormBuilderScope oldWidget) => oldWidget._formState != _formState;
+  bool updateShouldNotify(_FormBuilderScope oldWidget) =>
+      oldWidget._formState != _formState;
 }

--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -279,15 +279,10 @@ class FormBuilderState extends State<FormBuilder> {
     _focusOnInvalid = focusOnInvalid;
     final hasError = !_formKey.currentState!.validate();
     if (hasError) {
-      final wrongFields = fields.values.where((element) => element.hasError).toList();
-      if (wrongFields.isNotEmpty) {
-        if (focusOnInvalid) {
-          wrongFields.first.focus();
-        }
-        if (autoScrollWhenFocusOnInvalid) {
-          wrongFields.first.ensureScrollableVisibility();
-        }
-      }
+      scrollToFirstInvalidField(
+        focusOnInvalid: focusOnInvalid,
+        autoScrollWhenFocusOnInvalid: autoScrollWhenFocusOnInvalid,
+      );
     }
     return !hasError;
   }
@@ -326,10 +321,47 @@ class FormBuilderState extends State<FormBuilder> {
 
   /// Update fields errors of form.
   /// Useful when need update errors at once, after got errors from server.
-  void patchError(Map<String, String> errors) {
+  ///
+  /// Focus to first invalid field when has field invalid, if [focusOnInvalid] is `true`.
+  /// By default `true`
+  ///
+  /// Auto scroll to first invalid field focused if [autoScrollWhenFocusOnInvalid] is `true`.
+  /// By default `false`.
+  ///
+  /// Note: If a invalid field is from type **TextField** and will focused,
+  /// the form will auto scroll to show this invalid field.
+  /// In this case, the automatic scroll happens because is a behavior inside the framework,
+  /// not because [autoScrollWhenFocusOnInvalid] is `true`.
+  void patchError(Map<String, String> errors, {bool focusOnInvalid = true, bool autoScrollWhenFocusOnInvalid = false}) {
     errors.forEach((key, value) {
       _fields[key]?.invalidate(value);
     });
+    scrollToFirstInvalidField(
+      focusOnInvalid: focusOnInvalid,
+      autoScrollWhenFocusOnInvalid: autoScrollWhenFocusOnInvalid,
+    );
+  }
+
+  /// Focus to first invalid field when has field invalid, if [focusOnInvalid] is `true`.
+  /// By default `true`
+  ///
+  /// Auto scroll to first invalid field focused if [autoScrollWhenFocusOnInvalid] is `true`.
+  /// By default `false`.
+  ///
+  /// Note: If a invalid field is from type **TextField** and will focused,
+  /// the form will auto scroll to show this invalid field.
+  /// In this case, the automatic scroll happens because is a behavior inside the framework,
+  /// not because [autoScrollWhenFocusOnInvalid] is `true`.
+  void scrollToFirstInvalidField({bool focusOnInvalid = true, bool autoScrollWhenFocusOnInvalid = false}) {
+    final wrongFields = fields.values.where((element) => element.hasError).toList();
+    if (wrongFields.isNotEmpty) {
+      if (focusOnInvalid) {
+        wrongFields.first.focus();
+      }
+      if (autoScrollWhenFocusOnInvalid) {
+        wrongFields.first.ensureScrollableVisibility();
+      }
+    }
   }
 
   @override


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #???

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->
Connected to #???

## Solution description
This method help us to add errors to fields at once.
This is useful if form need to validate by server.

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [ ] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme
