### PR TITLE
fix: dropdown-hint-missing

### DIFF
--- a/lib/src/fields/form_builder_dropdown.dart
+++ b/lib/src/fields/form_builder_dropdown.dart
@@ -295,6 +295,7 @@ class FormBuilderDropdown<T> extends FormBuilderFieldDecoration<T> {
            final hasValue = items.map((e) => e.value).contains(field.value);
            return InputDecorator(
              decoration: state.decoration,
+             isEmpty: !hasValue,
              child: DropdownButton<T>(
                menuWidth: menuWidth,
                padding: padding,


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #1447 

## Solution description

The hint is only shown on an InputDecorator based on several states. One thing that *has* to be set for the hint to show is `isEmpty: true`, however this was not passed to the decorator from the dropdown field, thus always hiding the hint and label, regardless of contents.

## Screenshots or Videos

Repro-Widget (boilerplate omitted for brevity):

```dart
FormBuilderDropdown(
  items: const [],
  decoration: InputDecoration(
    label: const Text('Example'),
    hintText: 'Hint is here',
  ),
)
```

On 10.0.1 this will not render `Hint is here`. With this PR it will.

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme
