### PR TITLE
feat: Add disabledPicker property to FormBuilderDateTimePicker

### DIFF
--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -123,7 +123,8 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
   final EntryModeChangeCallback? onEntryModeChanged;
   final bool barrierDismissible;
 
-  final bool readOnly;
+  /// If true, disables the picker so it's not shown when the field is tapped.
+  final bool disablePicker;
 
   /// Creates field for `Date`, `Time` and `DateTime` input
   FormBuilderDateTimePicker({
@@ -193,7 +194,7 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
     this.selectableDayPredicate,
     this.anchorPoint,
     this.onEntryModeChanged,
-    this.readOnly = false,
+    this.disablePicker = false,
     this.barrierDismissible = true,
   }) : super(
          builder: (FormFieldState<DateTime?> field) {
@@ -202,7 +203,7 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
            return FocusTraversalGroup(
              policy: ReadingOrderTraversalPolicy(),
              child: TextField(
-               onTap: readOnly ? () {} : () => state.showPicker(),
+               onTap: disablePicker ? () {} : () => state.showPicker(),
                textDirection: textDirection,
                textAlign: textAlign,
                textAlignVertical: textAlignVertical,

--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -123,6 +123,8 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
   final EntryModeChangeCallback? onEntryModeChanged;
   final bool barrierDismissible;
 
+  final bool readOnly;
+
   /// Creates field for `Date`, `Time` and `DateTime` input
   FormBuilderDateTimePicker({
     super.key,
@@ -191,6 +193,7 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
     this.selectableDayPredicate,
     this.anchorPoint,
     this.onEntryModeChanged,
+    this.readOnly = false,
     this.barrierDismissible = true,
   }) : super(
          builder: (FormFieldState<DateTime?> field) {
@@ -199,7 +202,7 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
            return FocusTraversalGroup(
              policy: ReadingOrderTraversalPolicy(),
              child: TextField(
-               onTap: () => state.showPicker(),
+               onTap: readOnly ? () {} : () => state.showPicker(),
                textDirection: textDirection,
                textAlign: textAlign,
                textAlignVertical: textAlignVertical,


### PR DESCRIPTION
This PR adds support for the `readOnly` property to `FormBuilderDateTimePicker`, bringing it in line with other form builder fields and Flutter's native `TextField` behavior.

## Changes Made
- Added `readOnly` property to `FormBuilderDateTimePicker` constructor with default value `false`
- Modified the `onTap` callback to conditionally prevent picker dialogs from opening when `readOnly` is `true`
- Updated documentation for the new property

## Behavior
When `readOnly: true`:
- ✅ Field displays the current date/time value normally
- ✅ Date/time picker dialogs do not open when tapping the field
- ✅ Field maintains normal visual appearance (not grayed out like `enabled: false`)
- ✅ Field remains focusable for accessibility
- ✅ Value is still accessible for form submission and validation
- ✅ Consistent with other FormBuilder fields API

## Usage Example
```dart
FormBuilderDateTimePicker(
  name: 'created_date',
  readOnly: true,
  initialValue: DateTime.now(),
  decoration: InputDecoration(
    labelText: 'Creation Date',
    hintText: 'This field is read-only',
  ),
)
```

## Use Cases
- Displaying creation/modification timestamps
- Showing calculated dates that shouldn't be modified
- Form sections that are conditionally editable based on user permissions
- Confirmation/review screens where data should be visible but not modifiable

## Breaking Changes
None - this is a backward-compatible addition with a sensible default value.