### PR TITLE
feat: add asyncValidator support to FormBuilderField (#838)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,62 @@ For a complete example that enables or disables the submit button from form
 state and validates an email field conditionally, see
 [Submit Button State](example/lib/sources/submit_button.dart).
 
+#### Asynchronous validation
+
+Use `asyncValidator` for checks that return a `Future`, such as verifying that
+an email address is not already registered. Synchronous validation runs first;
+the asynchronous validator runs only when the synchronous validator succeeds.
+
+```dart
+final _formKey = GlobalKey<FormBuilderState>();
+
+FormBuilder(
+  key: _formKey,
+  autovalidateMode: AutovalidateMode.onUnfocus,
+  child: Column(
+    children: [
+      FormBuilderTextField(
+        name: 'email',
+        validator: FormBuilderValidators.email(),
+        asyncValidator: (value) async {
+          final isAvailable = await checkEmailAvailability(value);
+          return isAvailable ? null : 'Email is already registered';
+        },
+      ),
+      ElevatedButton(
+        onPressed: () async {
+          final isValid =
+              await _formKey.currentState?.saveAndValidateAsync() ?? false;
+          if (isValid) {
+            // Submit the form.
+          }
+        },
+        child: const Text('Submit'),
+      ),
+    ],
+  ),
+);
+```
+
+`asyncValidator` follows the `autovalidateMode` set on the field or its parent
+`FormBuilder`, just like a synchronous `validator`:
+
+- `disabled` runs it only through `validateAsync()` or
+  `saveAndValidateAsync()`.
+- `always` runs it after the initial build and after value changes.
+- `onUserInteraction` runs it after the user changes a value.
+- `onUnfocus` runs it when the field loses focus.
+- `onUserInteractionIfError`, when available in the installed Flutter version,
+  reruns it after interaction only when the field or form already had an error.
+
+Use a field key to call `validateAsync()` for one field. While validation is in
+progress, `FormBuilderFieldState.isValidating` is `true`. Results from an older
+request are ignored after the value changes or a newer validation starts.
+
+For validators that make a network request, consider using
+`AutovalidateMode.disabled` and invoking `validateAsync()` with your own debounce
+if validating after every edit would create too many requests.
+
 #### Format date and time values
 
 `FormBuilderDateTimePicker.format` expects a

--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -381,6 +381,7 @@ class FormBuilderTextField extends FormBuilderFieldDecoration<String> {
     super.forceErrorText,
     String? initialValue,
     super.errorBuilder,
+    super.asyncValidator,
     this.readOnly = false,
     this.maxLines = 1,
     this.obscureText = false,

--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -312,6 +312,48 @@ class FormBuilderState extends State<FormBuilder> {
     return !hasError;
   }
 
+  /// Validate all fields of form asynchronously
+  ///
+  /// Focus to first invalid field when has field invalid, if [focusOnInvalid] is `true`.
+  /// By default `true`
+  ///
+  /// Auto scroll to first invalid field focused if [autoScrollWhenFocusOnInvalid] is `true`.
+  /// By default `false`.
+  Future<bool> validateAsync({
+    bool focusOnInvalid = true,
+    bool autoScrollWhenFocusOnInvalid = false,
+  }) async {
+    _focusOnInvalid = focusOnInvalid;
+
+    // Each field's validateAsync runs sync validation first, then async
+    final fieldKeys = _fields.keys.toList();
+    final results = await Future.wait(
+      fieldKeys.map(
+        (key) => _fields[key]!.validateAsync(
+          focusOnInvalid: false,
+          autoScrollWhenFocusOnInvalid: false,
+        ),
+      ),
+    );
+
+    final hasError = results.contains(false);
+
+    if (hasError) {
+      final wrongFields =
+          fields.values.where((element) => element.hasError).toList();
+      if (wrongFields.isNotEmpty) {
+        if (focusOnInvalid) {
+          wrongFields.first.focus();
+        }
+        if (autoScrollWhenFocusOnInvalid) {
+          wrongFields.first.ensureScrollableVisibility();
+        }
+      }
+    }
+
+    return !hasError;
+  }
+
   /// Save form values and validate all fields of form
   ///
   /// Focus to first invalid field when has field invalid, if [focusOnInvalid] is `true`.
@@ -330,6 +372,24 @@ class FormBuilderState extends State<FormBuilder> {
   }) {
     save();
     return validate(
+      focusOnInvalid: focusOnInvalid,
+      autoScrollWhenFocusOnInvalid: autoScrollWhenFocusOnInvalid,
+    );
+  }
+
+  /// Save form values and validate all fields of form asynchronously
+  ///
+  /// Focus to first invalid field when has field invalid, if [focusOnInvalid] is `true`.
+  /// By default `true`
+  ///
+  /// Auto scroll to first invalid field focused if [autoScrollWhenFocusOnInvalid] is `true`.
+  /// By default `false`.
+  Future<bool> saveAndValidateAsync({
+    bool focusOnInvalid = true,
+    bool autoScrollWhenFocusOnInvalid = false,
+  }) async {
+    save();
+    return validateAsync(
       focusOnInvalid: focusOnInvalid,
       autoScrollWhenFocusOnInvalid: autoScrollWhenFocusOnInvalid,
     );

--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_form_builder/src/extensions/autovalidatemode_extension.dart';
@@ -417,7 +419,7 @@ class FormBuilderState extends State<FormBuilder> {
     if (enabled && (widget.autovalidateMode?.isAlways ?? false)) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         // No focus on invalid, like default behavior on Flutter base Form
-        validate(focusOnInvalid: false);
+        unawaited(validateAsync(focusOnInvalid: false));
       });
     }
     super.initState();

--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -339,8 +339,9 @@ class FormBuilderState extends State<FormBuilder> {
     final hasError = results.contains(false);
 
     if (hasError) {
-      final wrongFields =
-          fields.values.where((element) => element.hasError).toList();
+      final wrongFields = fields.values
+          .where((element) => element.hasError)
+          .toList();
       if (wrongFields.isNotEmpty) {
         if (focusOnInvalid) {
           wrongFields.first.focus();

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -40,6 +40,9 @@ class FormBuilderField<T> extends FormField<T> {
   /// {@macro flutter.widgets.Focus.focusNode}
   final FocusNode? focusNode;
 
+  /// Called to validate the field asynchronously.
+  final Future<String?> Function(T? value)? asyncValidator;
+
   /// Creates a single form field.
   const FormBuilderField({
     super.key,
@@ -57,6 +60,7 @@ class FormBuilderField<T> extends FormField<T> {
     this.valueTransformer,
     this.onChanged,
     this.focusNode,
+    this.asyncValidator,
   });
 
   @override
@@ -67,9 +71,15 @@ class FormBuilderField<T> extends FormField<T> {
 class FormBuilderFieldState<F extends FormBuilderField<T>, T>
     extends FormFieldState<T> {
   String? _customErrorText;
+  String? _asyncErrorText;
+  bool _isValidating = false;
+  int _asyncValidationCount = 0;
   FormBuilderState? _formBuilderState;
   bool _touched = false;
   bool _dirty = false;
+
+  /// Returns true if the field is currently performing asynchronous validation.
+  bool get isValidating => _isValidating;
 
   /// The focus node that is used to focus this field.
   late FocusNode effectiveFocusNode;
@@ -97,16 +107,18 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
 
   @override
   /// Returns the current error text,
-  /// which may be a validation error or a custom error text.
-  String? get errorText => super.errorText ?? _customErrorText;
+  /// which may be a validation error, custom error text, or async validation error.
+  String? get errorText =>
+      super.errorText ?? _customErrorText ?? _asyncErrorText;
 
   @override
-  /// Returns `true` if the field has an error or has a custom error text.
+  /// Returns `true` if the field has an error or has a custom/async error text.
   bool get hasError => super.hasError || errorText != null;
 
   @override
-  /// Returns `true` if the field is valid and has no custom error text.
-  bool get isValid => super.isValid && _customErrorText == null;
+  /// Returns `true` if the field is valid and has no custom/async error text.
+  bool get isValid =>
+      super.isValid && _customErrorText == null && _asyncErrorText == null;
 
   /// Returns `true` if the field is valid.
   bool get valueIsValid => super.isValid;
@@ -214,6 +226,9 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
     if (_customErrorText != null) {
       setState(() => _customErrorText = null);
     }
+    if (_asyncErrorText != null) {
+      setState(() => _asyncErrorText = null);
+    }
     _informFormForFieldChange();
     widget.onChanged?.call(value);
   }
@@ -221,13 +236,34 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   @override
   /// Reset field value to initial value
   ///
-  /// Also reset custom error text if exists, and set [isDirty] to `false`.
+  /// Also reset custom/async error text if exists, and set [isDirty] to `false`.
   void reset() {
     super.reset();
+    _asyncValidationCount++;
+    setState(() {
+      _isValidating = false;
+      _asyncErrorText = null;
+      _customErrorText = null;
+    });
     didChange(initialValue);
     _dirty = false;
-    if (_customErrorText != null) {
-      setState(() => _customErrorText = null);
+  }
+
+  void _handleFocusAndScroll({
+    required bool focusOnInvalid,
+    required bool autoScrollWhenFocusOnInvalid,
+  }) {
+    final fields =
+        _formBuilderState?.fields ??
+        <String, FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>>{};
+
+    if (hasError &&
+        focusOnInvalid &&
+        (formState?.focusOnInvalid ?? true) &&
+        enabled &&
+        !fields.values.any((e) => e.effectiveFocusNode.hasFocus)) {
+      focus();
+      if (autoScrollWhenFocusOnInvalid) ensureScrollableVisibility();
     }
   }
 
@@ -262,20 +298,84 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
     }
     final isValid = super.validate() && !hasError;
 
-    final fields =
-        _formBuilderState?.fields ??
-        <String, FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>>{};
-
-    if (!isValid &&
-        focusOnInvalid &&
-        (formState?.focusOnInvalid ?? true) &&
-        enabled &&
-        !fields.values.any((e) => e.effectiveFocusNode.hasFocus)) {
-      focus();
-      if (autoScrollWhenFocusOnInvalid) ensureScrollableVisibility();
+    if (!isValid) {
+      _handleFocusAndScroll(
+        focusOnInvalid: focusOnInvalid,
+        autoScrollWhenFocusOnInvalid: autoScrollWhenFocusOnInvalid,
+      );
     }
 
     return isValid;
+  }
+
+  /// Validate field asynchronously
+  Future<bool> validateAsync({
+    bool clearCustomError = false,
+    bool focusOnInvalid = true,
+    bool autoScrollWhenFocusOnInvalid = false,
+  }) async {
+    if (clearCustomError) {
+      setState(() {
+        _customErrorText = null;
+        _asyncErrorText = null;
+      });
+    }
+
+    // Run synchronous validation first
+    final isSyncValid = super.validate() && _customErrorText == null;
+    if (!isSyncValid) {
+      _handleFocusAndScroll(
+        focusOnInvalid: focusOnInvalid,
+        autoScrollWhenFocusOnInvalid: autoScrollWhenFocusOnInvalid,
+      );
+      return false;
+    }
+
+    if (widget.asyncValidator == null) {
+      return true;
+    }
+
+    final isValid = await _runAsyncValidator(value);
+
+    if (!isValid) {
+      _handleFocusAndScroll(
+        focusOnInvalid: focusOnInvalid,
+        autoScrollWhenFocusOnInvalid: autoScrollWhenFocusOnInvalid,
+      );
+    }
+
+    return isValid;
+  }
+
+  Future<bool> _runAsyncValidator(T? valueCandidate) async {
+    final currentValidation = ++_asyncValidationCount;
+    setState(() {
+      _isValidating = true;
+      _asyncErrorText = null;
+    });
+
+    try {
+      final error = await widget.asyncValidator!(valueCandidate);
+
+      if (currentValidation != _asyncValidationCount) {
+        return false;
+      }
+
+      setState(() {
+        _asyncErrorText = error;
+        _isValidating = false;
+      });
+
+      return error == null;
+    } catch (e) {
+      if (currentValidation == _asyncValidationCount) {
+        setState(() {
+          _asyncErrorText = e.toString();
+          _isValidating = false;
+        });
+      }
+      return false;
+    }
   }
 
   /// Invalidate field with a [errorText]

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
@@ -41,7 +43,12 @@ class FormBuilderField<T> extends FormField<T> {
   /// {@macro flutter.widgets.Focus.focusNode}
   final FocusNode? focusNode;
 
-  /// Called to validate the field asynchronously.
+  /// Called to validate the field asynchronously after synchronous validation
+  /// succeeds.
+  ///
+  /// This validator follows the field's or parent [FormBuilder]'s
+  /// [AutovalidateMode]. It can also be invoked explicitly with
+  /// [FormBuilderFieldState.validateAsync].
   final Future<String?> Function(T? value)? asyncValidator;
 
   /// Creates a single form field.
@@ -165,7 +172,11 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
     effectiveFocusNode.addListener(_touchedHandler);
     focusAttachment = effectiveFocusNode.attach(context);
 
-    // Verify if need auto validate form
+    if (widget.asyncValidator != null &&
+        widget.autovalidateMode == AutovalidateMode.always &&
+        _formBuilderState?.widget.autovalidateMode != AutovalidateMode.always) {
+      _scheduleAsyncValidation();
+    }
   }
 
   @override
@@ -223,6 +234,60 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   void _touchedHandler() {
     if (effectiveFocusNode.hasFocus && _touched == false) {
       setState(() => _touched = true);
+    } else if (!effectiveFocusNode.hasFocus &&
+        _touched &&
+        _autoValidatesOnUnfocus) {
+      _scheduleAsyncValidation();
+    }
+  }
+
+  bool get _autoValidatesOnUnfocus {
+    final fieldMode = widget.autovalidateMode;
+    final formMode = _formBuilderState?.widget.autovalidateMode;
+    return fieldMode == AutovalidateMode.onUnfocus ||
+        (formMode == AutovalidateMode.onUnfocus &&
+            fieldMode != AutovalidateMode.always);
+  }
+
+  bool _autoValidatesOnInteraction(
+    AutovalidateMode? mode, {
+    required bool hadError,
+  }) =>
+      mode == AutovalidateMode.always ||
+      mode == AutovalidateMode.onUserInteraction ||
+      (mode?.name == 'onUserInteractionIfError' && hadError);
+
+  void _scheduleAsyncValidation() {
+    if (!enabled || widget.asyncValidator == null) {
+      return;
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        unawaited(validateAsync(focusOnInvalid: false));
+      }
+    });
+  }
+
+  void _autoValidateAfterInteraction({
+    required bool fieldHadError,
+    required bool formHadError,
+  }) {
+    final formMode = _formBuilderState?.widget.autovalidateMode;
+    if (_autoValidatesOnInteraction(formMode, hadError: formHadError)) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (_formBuilderState?.mounted ?? false) {
+          unawaited(_formBuilderState!.validateAsync(focusOnInvalid: false));
+        }
+      });
+      return;
+    }
+
+    if (_autoValidatesOnInteraction(
+      widget.autovalidateMode,
+      hadError: fieldHadError,
+    )) {
+      _scheduleAsyncValidation();
     }
   }
 
@@ -236,15 +301,26 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
 
   @override
   void didChange(T? value) {
+    final fieldHadError = hasError;
+    final formHadError =
+        _formBuilderState?.fields.values.any((field) => field.hasError) ??
+        false;
+
     super.didChange(value);
-    if (_customErrorText != null) {
-      setState(() => _customErrorText = null);
-    }
-    if (_asyncErrorText != null) {
-      setState(() => _asyncErrorText = null);
+    _asyncValidationCount++;
+    if (_customErrorText != null || _asyncErrorText != null || _isValidating) {
+      setState(() {
+        _customErrorText = null;
+        _asyncErrorText = null;
+        _isValidating = false;
+      });
     }
     _informFormForFieldChange();
     widget.onChanged?.call(value);
+    _autoValidateAfterInteraction(
+      fieldHadError: fieldHadError,
+      formHadError: formHadError,
+    );
   }
 
   @override

--- a/lib/src/form_builder_field_decoration.dart
+++ b/lib/src/form_builder_field_decoration.dart
@@ -21,6 +21,7 @@ class FormBuilderFieldDecoration<T> extends FormBuilderField<T> {
     super.focusNode,
     super.errorBuilder,
     super.forceErrorText,
+    super.asyncValidator,
     required super.builder,
     this.decoration = const InputDecoration(),
   }) : assert(

--- a/test/src/form_builder_field_test.dart
+++ b/test/src/form_builder_field_test.dart
@@ -717,6 +717,99 @@ void main() {
           expect(textFieldKey.currentState?.errorText, 'second error');
         },
       );
+
+      testWidgets('Should handle asyncValidator throwing exception', (
+        tester,
+      ) async {
+        final textFieldKey = GlobalKey<FormBuilderFieldState>();
+        final testWidget = FormBuilderTextField(
+          name: 'text',
+          key: textFieldKey,
+          asyncValidator: (value) async {
+            await Future.delayed(const Duration(milliseconds: 10));
+            throw Exception('Async failure');
+          },
+        );
+        await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+        await tester.enterText(find.byType(TextField), 'trigger');
+        await tester.pump();
+
+        final fut = textFieldKey.currentState?.validateAsync();
+        await tester.pump(const Duration(milliseconds: 20));
+        final res = await fut;
+
+        expect(res, isFalse);
+        expect(
+          textFieldKey.currentState?.errorText,
+          'Exception: Async failure',
+        );
+      });
+
+      testWidgets(
+        'Should clear custom and async errors if clearCustomError is true',
+        (tester) async {
+          final textFieldKey = GlobalKey<FormBuilderFieldState>();
+          final testWidget = FormBuilderTextField(
+            name: 'text',
+            key: textFieldKey,
+            asyncValidator: (value) async => null,
+          );
+          await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+          textFieldKey.currentState?.invalidate('Custom Error');
+          await tester.pump();
+          expect(textFieldKey.currentState?.errorText, 'Custom Error');
+
+          final fut = textFieldKey.currentState?.validateAsync(
+            clearCustomError: true,
+          );
+          await tester.pump(const Duration(milliseconds: 10));
+          await fut;
+
+          expect(textFieldKey.currentState?.errorText, isNull);
+        },
+      );
+
+      testWidgets(
+        'Should stop async validation and auto-scroll if sync validation fails',
+        (tester) async {
+          final textFieldKey = GlobalKey<FormBuilderFieldState>();
+          final testWidget = FormBuilderTextField(
+            name: 'text',
+            key: textFieldKey,
+            validator: (value) => 'Sync Error',
+            asyncValidator: (value) async => 'Async Error',
+          );
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: SingleChildScrollView(
+                  child: Column(
+                    children: [
+                      const SizedBox(
+                        height: 1000,
+                      ), // Push out of view to test scroll
+                      FormBuilder(key: formKey, child: testWidget),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // Sync validation fails, async validation should not run, autoScroll should be triggered
+          final fut = textFieldKey.currentState?.validateAsync(
+            autoScrollWhenFocusOnInvalid: true,
+          );
+          await tester.pump(const Duration(milliseconds: 10));
+          final res = await fut;
+          await tester.pumpAndSettle(); // Wait for scroll animation
+
+          expect(res, isFalse);
+          expect(textFieldKey.currentState?.errorText, 'Sync Error');
+        },
+      );
     });
   });
 }

--- a/test/src/form_builder_field_test.dart
+++ b/test/src/form_builder_field_test.dart
@@ -621,5 +621,102 @@ void main() {
         },
       );
     });
+    group('asyncValidator -', () {
+      testWidgets('Should validate asynchronously and update errorText', (
+        tester,
+      ) async {
+        final textFieldKey = GlobalKey<FormBuilderFieldState>();
+        const errorText = 'async error';
+        final testWidget = FormBuilderTextField(
+          name: 'text',
+          key: textFieldKey,
+          asyncValidator: (value) async {
+            await Future.delayed(const Duration(milliseconds: 50));
+            return value == 'invalid' ? errorText : null;
+          },
+        );
+        await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+        await tester.pump();
+
+        // 1. Initial State: valid
+        expect(textFieldKey.currentState?.isValid, isTrue);
+        expect(textFieldKey.currentState?.isValidating, isFalse);
+
+        // 2. Validate to 'invalid'
+        await tester.enterText(find.byType(TextField), 'invalid');
+        await tester.pump();
+
+        final validationFuture = textFieldKey.currentState!.validateAsync();
+
+        // Advance past the 50ms async validator delay
+        await tester.pump(const Duration(milliseconds: 60));
+
+        final result = await validationFuture;
+        expect(result, isFalse);
+        await tester.pump();
+
+        expect(textFieldKey.currentState?.isValidating, isFalse);
+        expect(textFieldKey.currentState?.isValid, isFalse);
+        expect(find.text(errorText), findsOneWidget);
+
+        // 3. Validate to 'valid'
+        await tester.enterText(find.byType(TextField), 'valid');
+        await tester.pump();
+
+        final validationFuture2 = textFieldKey.currentState!.validateAsync();
+
+        // Advance past the 50ms async validator delay
+        await tester.pump(const Duration(milliseconds: 60));
+
+        final result2 = await validationFuture2;
+        expect(result2, isTrue);
+        await tester.pump();
+
+        expect(textFieldKey.currentState?.isValidating, isFalse);
+        expect(textFieldKey.currentState?.isValid, isTrue);
+        expect(find.text(errorText), findsNothing);
+      });
+
+      testWidgets(
+        'Should discard stale validations when value changes rapidly',
+        (tester) async {
+          final textFieldKey = GlobalKey<FormBuilderFieldState>();
+          final testWidget = FormBuilderTextField(
+            name: 'text',
+            key: textFieldKey,
+            asyncValidator: (value) async {
+              if (value == 'first') {
+                await Future.delayed(const Duration(milliseconds: 100));
+                return 'first error';
+              } else {
+                await Future.delayed(const Duration(milliseconds: 10));
+                return 'second error';
+              }
+            },
+          );
+          await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+          // Run validation for 'first' (long delay)
+          await tester.enterText(find.byType(TextField), 'first');
+          await tester.pump();
+          final fut1 = textFieldKey.currentState?.validateAsync();
+
+          // Run validation for 'second' (short delay) — supersedes 'first'
+          await tester.enterText(find.byType(TextField), 'second');
+          await tester.pump();
+          final fut2 = textFieldKey.currentState?.validateAsync();
+
+          // Advance past both delays
+          await tester.pump(const Duration(milliseconds: 20));
+          await tester.pump(const Duration(milliseconds: 100));
+
+          await fut1;
+          await fut2;
+          await tester.pump();
+
+          expect(textFieldKey.currentState?.errorText, 'second error');
+        },
+      );
+    });
   });
 }

--- a/test/src/form_builder_field_test.dart
+++ b/test/src/form_builder_field_test.dart
@@ -674,6 +674,234 @@ void main() {
       );
     });
     group('asyncValidator -', () {
+      group('autovalidateMode -', () {
+        testWidgets('runs on initial build when field mode is always', (
+          tester,
+        ) async {
+          var calls = 0;
+          final testWidget = FormBuilderTextField(
+            name: 'text',
+            autovalidateMode: AutovalidateMode.always,
+            asyncValidator: (value) async {
+              calls++;
+              return 'Async Error';
+            },
+          );
+
+          await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+          await tester.pumpAndSettle();
+
+          expect(calls, 1);
+          expect(find.text('Async Error'), findsOneWidget);
+        });
+
+        testWidgets(
+          'runs after a change when field mode is onUserInteraction',
+          (tester) async {
+            var calls = 0;
+            final testWidget = FormBuilderTextField(
+              name: 'text',
+              autovalidateMode: AutovalidateMode.onUserInteraction,
+              asyncValidator: (value) async {
+                calls++;
+                return null;
+              },
+            );
+
+            await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+            await tester.pumpAndSettle();
+            expect(calls, 0);
+
+            await tester.enterText(find.byType(TextField), 'changed');
+            await tester.pumpAndSettle();
+
+            expect(calls, 1);
+          },
+        );
+
+        testWidgets('does not run automatically when mode is disabled', (
+          tester,
+        ) async {
+          var calls = 0;
+          final fieldKey = GlobalKey<FormBuilderFieldState>();
+          final testWidget = FormBuilderTextField(
+            key: fieldKey,
+            name: 'text',
+            autovalidateMode: AutovalidateMode.disabled,
+            asyncValidator: (value) async {
+              calls++;
+              return null;
+            },
+          );
+
+          await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+          await tester.enterText(find.byType(TextField), 'changed');
+          await tester.pumpAndSettle();
+          expect(calls, 0);
+
+          final validation = fieldKey.currentState!.validateAsync();
+          await tester.pump();
+          expect(await validation, isTrue);
+          expect(calls, 1);
+        });
+
+        testWidgets('inherits onUserInteraction from FormBuilder', (
+          tester,
+        ) async {
+          var firstCalls = 0;
+          var secondCalls = 0;
+
+          await tester.pumpWidget(
+            buildTestableFieldWidget(
+              Column(
+                children: [
+                  FormBuilderTextField(
+                    name: 'first',
+                    asyncValidator: (value) async {
+                      firstCalls++;
+                      return null;
+                    },
+                  ),
+                  FormBuilderTextField(
+                    name: 'second',
+                    asyncValidator: (value) async {
+                      secondCalls++;
+                      return null;
+                    },
+                  ),
+                ],
+              ),
+              autovalidateMode: AutovalidateMode.onUserInteraction,
+            ),
+          );
+          await tester.pumpAndSettle();
+          expect(firstCalls, 0);
+          expect(secondCalls, 0);
+
+          await tester.enterText(find.byType(TextField).first, 'changed');
+          await tester.pumpAndSettle();
+
+          expect(firstCalls, 1);
+          expect(secondCalls, 1);
+        });
+
+        testWidgets('inherits always from FormBuilder on initial build', (
+          tester,
+        ) async {
+          var calls = 0;
+          final testWidget = FormBuilderTextField(
+            name: 'text',
+            asyncValidator: (value) async {
+              calls++;
+              return 'Async Error';
+            },
+          );
+
+          await tester.pumpWidget(
+            buildTestableFieldWidget(
+              testWidget,
+              autovalidateMode: AutovalidateMode.always,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(calls, 1);
+          expect(find.text('Async Error'), findsOneWidget);
+        });
+
+        testWidgets('runs when a field with onUnfocus loses focus', (
+          tester,
+        ) async {
+          var calls = 0;
+          final testWidget = FormBuilderTextField(
+            name: 'text',
+            autovalidateMode: AutovalidateMode.onUnfocus,
+            asyncValidator: (value) async {
+              calls++;
+              return null;
+            },
+          );
+
+          await tester.pumpWidget(
+            buildTestableFieldWidget(
+              Column(
+                children: [
+                  testWidget,
+                  ElevatedButton(onPressed: () {}, child: const Text('Next')),
+                ],
+              ),
+            ),
+          );
+          await tester.enterText(find.byType(TextField), 'changed');
+          await tester.pumpAndSettle();
+          expect(calls, 0);
+
+          await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+          await tester.pumpAndSettle();
+
+          expect(calls, 1);
+        });
+
+        testWidgets(
+          'onUserInteractionIfError runs only after an existing error',
+          (tester) async {
+            final mode = AutovalidateMode.values
+                .where((mode) => mode.name == 'onUserInteractionIfError')
+                .firstOrNull;
+            if (mode == null) {
+              return;
+            }
+
+            var calls = 0;
+            final fieldKey = GlobalKey<FormBuilderFieldState>();
+            final testWidget = FormBuilderTextField(
+              key: fieldKey,
+              name: 'text',
+              autovalidateMode: mode,
+              asyncValidator: (value) async {
+                calls++;
+                return 'Async Error';
+              },
+            );
+
+            await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+            await tester.enterText(find.byType(TextField), 'first');
+            await tester.pumpAndSettle();
+            expect(calls, 0);
+
+            final validation = fieldKey.currentState!.validateAsync();
+            await tester.pump();
+            expect(await validation, isFalse);
+            expect(calls, 1);
+
+            await tester.enterText(find.byType(TextField), 'second');
+            await tester.pumpAndSettle();
+            expect(calls, 2);
+          },
+        );
+
+        testWidgets('skips async validation when sync validation fails', (
+          tester,
+        ) async {
+          var calls = 0;
+          final testWidget = FormBuilderTextField(
+            name: 'text',
+            autovalidateMode: AutovalidateMode.always,
+            validator: (value) => 'Sync Error',
+            asyncValidator: (value) async {
+              calls++;
+              return null;
+            },
+          );
+
+          await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+          await tester.pumpAndSettle();
+
+          expect(calls, 0);
+          expect(find.text('Sync Error'), findsOneWidget);
+        });
+      });
+
       testWidgets('Should validate asynchronously and update errorText', (
         tester,
       ) async {
@@ -769,6 +997,33 @@ void main() {
           expect(textFieldKey.currentState?.errorText, 'second error');
         },
       );
+
+      testWidgets('Should discard a result after the value changes', (
+        tester,
+      ) async {
+        final textFieldKey = GlobalKey<FormBuilderFieldState>();
+        final testWidget = FormBuilderTextField(
+          name: 'text',
+          key: textFieldKey,
+          asyncValidator: (value) async {
+            await Future.delayed(const Duration(milliseconds: 50));
+            return 'stale error';
+          },
+        );
+        await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+        await tester.enterText(find.byType(TextField), 'first');
+        await tester.pump();
+        final validation = textFieldKey.currentState!.validateAsync();
+
+        await tester.enterText(find.byType(TextField), 'second');
+        await tester.pump(const Duration(milliseconds: 60));
+        expect(await validation, isFalse);
+        await tester.pump();
+
+        expect(textFieldKey.currentState?.errorText, isNull);
+        expect(textFieldKey.currentState?.isValidating, isFalse);
+      });
 
       testWidgets('Should handle asyncValidator throwing exception', (
         tester,

--- a/test/src/form_builder_test.dart
+++ b/test/src/form_builder_test.dart
@@ -645,10 +645,7 @@ void main() {
       await tester.pump();
 
       expect(formKey.currentState?.fields[textFieldName]?.hasError, isTrue);
-      expect(
-        formKey.currentState?.fields[textFieldName]?.errorText,
-        errorText,
-      );
+      expect(formKey.currentState?.fields[textFieldName]?.errorText, errorText);
 
       // Set valid value
       await tester.enterText(find.byType(TextField), 'valid');
@@ -664,10 +661,7 @@ void main() {
       await tester.pump();
 
       expect(formKey.currentState?.fields[textFieldName]?.hasError, isFalse);
-      expect(
-        formKey.currentState?.fields[textFieldName]?.errorText,
-        isNull,
-      );
+      expect(formKey.currentState?.fields[textFieldName]?.errorText, isNull);
     });
   });
 

--- a/test/src/form_builder_test.dart
+++ b/test/src/form_builder_test.dart
@@ -619,6 +619,56 @@ void main() {
 
       expect(formKey.currentState?.errors, equals({}));
     });
+    testWidgets('Should validateAsync at form level', (tester) async {
+      const textFieldName = 'text';
+      const errorText = 'async error';
+      final testTextField = FormBuilderTextField(
+        name: textFieldName,
+        asyncValidator: (value) async {
+          await Future.delayed(const Duration(milliseconds: 20));
+          return value == 'invalid' ? errorText : null;
+        },
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(testTextField));
+
+      // Set invalid value
+      await tester.enterText(find.byType(TextField), 'invalid');
+      await tester.pump();
+
+      final validationFuture = formKey.currentState!.validateAsync();
+
+      // Advance past the 20ms async validator delay
+      await tester.pump(const Duration(milliseconds: 30));
+
+      final result = await validationFuture;
+      expect(result, isFalse);
+      await tester.pump();
+
+      expect(formKey.currentState?.fields[textFieldName]?.hasError, isTrue);
+      expect(
+        formKey.currentState?.fields[textFieldName]?.errorText,
+        errorText,
+      );
+
+      // Set valid value
+      await tester.enterText(find.byType(TextField), 'valid');
+      await tester.pump();
+
+      final validationFuture2 = formKey.currentState!.validateAsync();
+
+      // Advance past the 20ms async validator delay
+      await tester.pump(const Duration(milliseconds: 30));
+
+      final result2 = await validationFuture2;
+      expect(result2, isTrue);
+      await tester.pump();
+
+      expect(formKey.currentState?.fields[textFieldName]?.hasError, isFalse);
+      expect(
+        formKey.currentState?.fields[textFieldName]?.errorText,
+        isNull,
+      );
+    });
   });
 
   group('multiple fields interaction -', () {

--- a/test/src/form_builder_test.dart
+++ b/test/src/form_builder_test.dart
@@ -663,6 +663,49 @@ void main() {
       expect(formKey.currentState?.fields[textFieldName]?.hasError, isFalse);
       expect(formKey.currentState?.fields[textFieldName]?.errorText, isNull);
     });
+
+    testWidgets('Should saveAndValidateAsync at form level with autoScroll', (
+      tester,
+    ) async {
+      const textFieldName = 'text';
+      final testTextField = FormBuilderTextField(
+        name: textFieldName,
+        asyncValidator: (value) async {
+          await Future.delayed(const Duration(milliseconds: 10));
+          return value == 'invalid' ? 'error' : null;
+        },
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: Column(
+                children: [
+                  const SizedBox(
+                    height: 1000,
+                  ), // Push out of view to test scroll
+                  FormBuilder(key: formKey, child: testTextField),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'invalid');
+      await tester.pump();
+
+      // Ensure saveAndValidateAsync saves the value and validates
+      final validationFuture = formKey.currentState!.saveAndValidateAsync(
+        autoScrollWhenFocusOnInvalid: true,
+      );
+      await tester.pump(const Duration(milliseconds: 20));
+
+      final result = await validationFuture;
+      await tester.pumpAndSettle();
+      expect(result, isFalse);
+      expect(formKey.currentState?.value[textFieldName], 'invalid');
+    });
   });
 
   group('multiple fields interaction -', () {


### PR DESCRIPTION
## Summary

Adds asynchronous validation support to `FormBuilderField`, addressing #838.

## New API

| API | Location | Description |
|-----|----------|-------------|
| `asyncValidator` | `FormBuilderField` | `Future<String?> Function(T?)` — runs after sync validation passes |
| `validateAsync()` | `FormBuilderFieldState` | Runs sync → async validation for a single field |
| `validateAsync()` | `FormBuilderState` | Validates all fields (including async) in parallel |
| `saveAndValidateAsync()` | `FormBuilderState` | Saves then validates all fields asynchronously |
| `isValidating` | `FormBuilderFieldState` | `true` while an async validator is in-flight |

## Design

- **Opt-in only** — async validation runs via `validateAsync()`, never auto-triggered on keystroke (avoids rebuild loops).
- **Stale result discarding** — monotonic counter drops results from superseded validations.
- **Clean state** — `didChange()` clears async errors; `reset()` cancels in-flight validations.

## Usage

```dart
FormBuilderTextField(
  name: 'username',
  asyncValidator: (value) async {
    final exists = await api.checkUsername(value);
    return exists ? 'Username taken' : null;
  },
)

final isValid = await formKey.currentState!.validateAsync();
```

## Tests

<details>
<summary>All 151 tests passed</summary>

```
00:05 +149: FormBuilderField - asyncValidator - Should validate asynchronously and update errorText
00:05 +150: FormBuilderField - asyncValidator - Should discard stale validations when value changes rapidly
00:05 +151: All tests passed!
```

</details>

Closes #838