### PR TITLE
fix: forward the field error state to the checkbox in FormBuilderCheckbox #1503

### DIFF
--- a/lib/src/fields/form_builder_checkbox.dart
+++ b/lib/src/fields/form_builder_checkbox.dart
@@ -151,6 +151,7 @@ class FormBuilderCheckbox extends FormBuilderFieldDecoration<bool> {
                selected: selected,
                checkboxShape: shape,
                side: side,
+               isError: state.hasError,
              ),
            );
          },

--- a/test/src/fields/form_builder_checkbox_test.dart
+++ b/test/src/fields/form_builder_checkbox_test.dart
@@ -28,6 +28,33 @@ void main() {
       expect(formSave(), isTrue);
       expect(formValue(widgetName), isFalse);
     });
+    testWidgets('error state reaches the checkbox', (
+      WidgetTester tester,
+    ) async {
+      const widgetName = 'cb_error';
+      final testWidget = FormBuilderCheckbox(
+        name: widgetName,
+        title: const Text('Accept terms'),
+        initialValue: false,
+        validator: (value) => value == true ? null : 'required',
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+      CheckboxListTile tile() =>
+          tester.widget<CheckboxListTile>(find.byType(CheckboxListTile));
+
+      expect(tile().isError, isFalse);
+
+      expect(formSave(), isFalse);
+      await tester.pumpAndSettle();
+      expect(tile().isError, isTrue);
+
+      await tester.tap(find.byType(CheckboxListTile));
+      await tester.pumpAndSettle();
+      expect(formSave(), isTrue);
+      await tester.pumpAndSettle();
+      expect(tile().isError, isFalse);
+    });
     testWidgets('When press tab, field will be focused', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
Closes #1503

`FormBuilderCheckbox` never told the checkbox about the field's error state, so `WidgetStateBorderSide.resolveWith` / `fillColor` resolving `WidgetState.error` had no effect, as reported in the issue.

The builder now passes `isError: state.hasError` to the internal `CheckboxListTile`, which is the Material way to put the checkbox itself into the error state, so any `side`, `fillColor` or checkbox theme that resolves `WidgetState.error` starts working without new API surface.

Added a widget test: the checkbox reports `isError` after a failed validate and drops it once the value is valid again. `flutter test` and `flutter analyze` are clean.
