### PR TITLE
fix: scroll to first invalid field in visual order #1476

### DIFF
--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -278,6 +278,39 @@ class FormBuilderState extends State<FormBuilder> {
     _savedValue.addAll(_instantValue);
   }
 
+  /// First invalid field in visual reading order, not registration order.
+  ///
+  /// Dynamic fields register last, so [fields.values] can put a newly inserted
+  /// field after earlier ones even when it is first on screen.
+  FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>?
+  _firstInvalidField() {
+    final invalidFields = fields.values
+        .where((field) => field.hasError)
+        .toList();
+    if (invalidFields.length <= 1) {
+      return invalidFields.firstOrNull;
+    }
+
+    invalidFields.sort((a, b) {
+      final aBox = a.context.findRenderObject();
+      final bBox = b.context.findRenderObject();
+      if (aBox is! RenderBox || bBox is! RenderBox) {
+        return 0;
+      }
+      if (!aBox.hasSize || !bBox.hasSize) {
+        return 0;
+      }
+      final aOffset = aBox.localToGlobal(Offset.zero);
+      final bOffset = bBox.localToGlobal(Offset.zero);
+      final vertical = aOffset.dy.compareTo(bOffset.dy);
+      if (vertical != 0) {
+        return vertical;
+      }
+      return aOffset.dx.compareTo(bOffset.dx);
+    });
+    return invalidFields.first;
+  }
+
   /// Validate all fields of form
   ///
   /// Focus to first invalid field when has field invalid, if [focusOnInvalid] is `true`.
@@ -297,15 +330,13 @@ class FormBuilderState extends State<FormBuilder> {
     _focusOnInvalid = focusOnInvalid;
     final hasError = !_formKey.currentState!.validate();
     if (hasError) {
-      final wrongFields = fields.values
-          .where((element) => element.hasError)
-          .toList();
-      if (wrongFields.isNotEmpty) {
+      final firstInvalidField = _firstInvalidField();
+      if (firstInvalidField != null) {
         if (focusOnInvalid) {
-          wrongFields.first.focus();
+          firstInvalidField.focus();
         }
         if (autoScrollWhenFocusOnInvalid) {
-          wrongFields.first.ensureScrollableVisibility();
+          firstInvalidField.ensureScrollableVisibility();
         }
       }
     }

--- a/test/src/form_builder_test.dart
+++ b/test/src/form_builder_test.dart
@@ -747,6 +747,75 @@ void main() {
       expect(find.text('required'), findsNothing);
     });
   });
+
+  group('autoScrollWhenFocusOnInvalid -', () {
+    testWidgets('Should scroll to a dynamically inserted first invalid field', (
+      tester,
+    ) async {
+      late StateSetter setShowField;
+      var showDynamicField = false;
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StatefulBuilder(
+              builder: (context, setState) {
+                setShowField = setState;
+                return SingleChildScrollView(
+                  controller: scrollController,
+                  child: FormBuilder(
+                    key: formKey,
+                    child: Column(
+                      children: [
+                        if (showDynamicField)
+                          FormBuilderTextField(
+                            name: 'dynamic',
+                            validator: (_) => 'error',
+                          ),
+                        const SizedBox(height: 1200),
+                        FormBuilderTextField(
+                          name: 'static',
+                          validator: (_) => 'error',
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(formKey.currentState?.fields.keys.toList(), ['static']);
+
+      showDynamicField = true;
+      setShowField(() {});
+      await tester.pumpAndSettle();
+
+      expect(formKey.currentState?.fields.keys.toList(), ['static', 'dynamic']);
+      expect(scrollController.offset, 0);
+
+      expect(
+        formKey.currentState?.saveAndValidate(
+          focusOnInvalid: false,
+          autoScrollWhenFocusOnInvalid: true,
+        ),
+        isFalse,
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        scrollController.offset,
+        lessThan(200),
+        reason:
+            'Should scroll to the dynamically inserted field at the top, '
+            'not the later-registered field below the spacer',
+      );
+    });
+  });
 }
 
 // simple stateful widget that can hide and show its child with the intent of


### PR DESCRIPTION
## Bug Description

`saveAndValidate(autoScrollWhenFocusOnInvalid: true)` skipped a field that was inserted later, even when that field was first on screen.

Fixes #1476

## Root Cause

`validate()` treated `fields.values.first` as the first invalid field. That map is registration order. A dynamic field still registers last, so scroll/focus went to an older field.

## Fix

Pick the first invalid field by render position (top-to-bottom, then left-to-right) instead of insertion order.

## How to Verify

1. Add a field after others are already registered, but place it above them.
2. Call `saveAndValidate(focusOnInvalid: false, autoScrollWhenFocusOnInvalid: true)`.
3. The form should scroll to the new field, not the first one that was registered.

## Test Plan

- [x] Added a widget test that reproduces the issue repro (dynamic field at the top, static field below a spacer)
- [x] Confirmed the new test fails on current main (`offset == 696`) and passes with this change
- [x] `flutter test` — 151 passed
- [x] `flutter analyze` on the touched files — clean

## Risk Assessment

Low. Same validate path, only the “first invalid field” choice changes. Static forms keep their previous visual order.